### PR TITLE
🚀 release: v1.2.0

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,3 +1,12 @@
 # Server Configuration
 PORT=3000
 NODE_ENV=development
+
+# Stats Tracking (disabled by default - privacy-first approach)
+# Set to 'true' to track which GitHub repositories use this service
+# When disabled, no tracking occurs and Redis is not required
+ENABLE_STATS=false
+
+# Redis Configuration (only required if ENABLE_STATS=true)
+# Example: redis://default:password@host:port or redis://localhost:6379
+REDIS_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist/
 .claude/
 .vscode/
 pnpm-workspace.yaml
+
+# Environment variables (contains sensitive data)
+.env
+.env.local
+.env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 .claude/
 .vscode/
 pnpm-workspace.yaml
+package-lock.json
 
 # Environment variables (contains sensitive data)
 .env

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Health check endpoint for monitoring.
 
 The UI includes presets for quick access:
 
-**Gradients**: `1a1a1a-4a4a4a` (Midnight) • `ec4899-3b82f6` (Vibe) • `14b8a6-06b6d4` (Ocean)
+**Gradients**: `1a1a1a-4a4a4a` (Midnight) • `ec4899-3b82f6` (Vibe) • `14b8a6-06b6d4` (Ocean) • `431586-9231A8` (Railway) 🆕 • `F38020-FBAB41` (Cloudflare) 🆕 • `E7F9FF-90C4E8` (OSSPH)
 
-**Solids**: `dbeafe`/`3b82f6` (OSSPH) • `fee2e2`/`bb2c2c` (Molty) • `fde8e3`/`de7356` (Claude) • `f3f4f6`/`1f2937` (Minimal)
+**Solids**: `fee2e2`/`bb2c2c` (Molty) • `fde8e3`/`de7356` (Claude) • `10a37f`/`ffffff` (GPT) • `f3f4f6`/`1f2937` (Minimal)
 
 **Special**: `00000000`/`ffffff` (Transparent)
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,65 @@ Projects and organizations using GitHub Repo Banner:
 - [gogcli](https://github.com/steipete/gogcli) by [steipete](https://github.com/steipete) - Google in your terminal
 - [BetterGov PH](https://github.com/bettergovph/bettergov) - Making government services better for Filipinos
 
+## 🔒 Privacy & Transparency
+
+**Privacy by default.** This service does **NOT** track anything by default. If you're using the hosted version at `ghrb.waren.build`, stats tracking status is available at `/health`.
+
+### What We Track (When Enabled)
+- ✅ **Repository names only** - GitHub repository URLs from browser Referer headers
+- ✅ **Public data only** - Already publicly visible on GitHub
+
+### What We DON'T Track
+- ❌ No IP addresses
+- ❌ No personal information  
+- ❌ No user identities
+- ❌ No analytics or behavioral data
+- ❌ No cookies or tracking pixels
+- ❌ No timestamps or usage patterns
+
+### Why Track (When Enabled)
+Understanding which repositories use this service helps:
+- Gauge community value and impact
+- Make informed maintenance decisions
+- Justify resources for this free service
+
+### Your Data Rights
+- **Full transparency**: View tracked data at `/stats` (when enabled)
+- **Opt-out**: Self-host with stats disabled (default)
+- **Open source**: Review tracking code in this repository
+
+### Self-Hosting Privacy
+**Self-hosted instances have stats disabled by default.** To enable (optional):
+1. Set `ENABLE_STATS=true` in your `.env`
+2. Add Redis service to your Railway project
+3. See [Railway Deployment](#-railway-deployment) below
+
+## 🚂 Railway Deployment
+
+### Basic Deployment (Stats Disabled - Default)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/github-repo-banner?referralCode=KN9JqT)
+
+No additional configuration needed. The service runs without stats tracking.
+
+### With Stats Tracking (Optional)
+
+If you want to track which repositories use your instance:
+
+1. **Deploy the service** using the button above
+2. **Add Redis service** in Railway dashboard:
+   - Click "New" → "Database" → "Add Redis"
+   - Railway automatically sets `REDIS_URL`
+3. **Enable stats** in your service variables:
+   - Go to your service settings
+   - Add variable: `ENABLE_STATS=true`
+4. **Redeploy** your service
+
+**Accessing Stats:**
+- View at: `https://your-service.railway.app/stats`
+- Health check includes stats status: `https://your-service.railway.app/health`
+
+**Cost Note:** Redis on Railway has a free tier, then usage-based pricing. Stats tracking is lightweight and should stay within free limits for moderate traffic.
+
 ## 🔌 API Reference
 
 ### `GET /banner`
@@ -122,10 +181,51 @@ Interactive banner generator UI with live preview.
 
 ### `GET /health`
 
-Health check endpoint for monitoring.
+Health check endpoint for monitoring and stats status.
 
+**Response (stats disabled):**
 ```json
-{ "status": "ok", "timestamp": "2026-02-01T00:00:00.000Z" }
+{
+  "status": "ok",
+  "timestamp": "2026-02-01T00:00:00.000Z",
+  "stats": {
+    "enabled": false
+  }
+}
+```
+
+**Response (stats enabled):**
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-02-01T00:00:00.000Z",
+  "stats": {
+    "enabled": true,
+    "endpoint": "/stats"
+  }
+}
+```
+
+### `GET /stats`
+
+View repository tracking statistics (when enabled).
+
+**Response (stats disabled):**
+```json
+{
+  "enabled": false,
+  "message": "Stats tracking is disabled"
+}
+```
+
+**Response (stats enabled):**
+```json
+{
+  "enabled": true,
+  "totalRepositories": 42,
+  "repositories": ["owner/repo1", "owner/repo2"],
+  "note": "Only tracking public GitHub repositories using this service"
+}
 ```
 
 ## 🎨 Color Presets
@@ -159,7 +259,13 @@ pnpm start    # Start production server
 ```env
 PORT=3000              # Server port
 NODE_ENV=development   # Environment mode
+
+# Stats Tracking (disabled by default - privacy-first)
+ENABLE_STATS=false     # Set to 'true' to enable repository tracking
+REDIS_URL=             # Required only if ENABLE_STATS=true
 ```
+
+See `.example.env` for complete documentation.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ When you deploy your own copy, you're directly supporting this project! 💖
 - 💧 **Opacity Control** - 8-digit hex codes with alpha channel (RRGGBBAA)
 - 🔤 **Google Fonts Integration** - Use any font from Google Fonts for custom typography
 - 😀 **Native Emoji** - Full emoji support with proper rendering
+- 🎯 **Simple Icons Support** - Use 3000+ brand icons with `![slug]` syntax (e.g., `![github]`, `![react]`)
 - 📥 **SVG & PNG Download** - Download banners as SVG or PNG directly from the UI
 - ⚡ **Lightning Fast** - Built with Hono framework for optimal performance
 - 🔒 **Secure** - Input sanitization and validation
@@ -67,6 +68,17 @@ https://ghrb.waren.build/banner?header=%F0%9F%A6%9EOpenClaw&subheader=Your+own+p
 
 ![Emoji Example](https://ghrb.waren.build/banner?header=%F0%9F%A6%9EOpenClaw&subheader=Your+own+personal+AI+assistant.&bg=fee2e2&color=bb2c2c&support=true)
 
+**With Brand Icons (Simple Icons)**
+
+```text
+https://ghrb.waren.build/banner?header=![github]+Hello+World&bg=1a1a1a-4a4a4a&color=ffffff
+https://ghrb.waren.build/banner?header=![react]+![typescript]+Modern+Stack&bg=14b8a6-06b6d4&color=ffffff
+```
+
+![Icon Example](https://ghrb.waren.build/banner?header=![github]+Hello+World&bg=1a1a1a-4a4a4a&color=ffffff)
+
+> Use `![slug]` syntax to embed any icon from [Simple Icons](https://simpleicons.org). Over 3000+ brand icons available! Icons automatically adapt to your text color.
+
 **Transparent/Opacity**
   
 ```text
@@ -89,13 +101,20 @@ Projects and organizations using GitHub Repo Banner:
 - ✅ **Repository names only** - GitHub repository URLs from browser Referer headers
 - ✅ **Public data only** - Already publicly visible on GitHub
 
+### What We Log (Always)
+- 📊 **User actions** - Button clicks (Copy Markdown, Download SVG, etc.) and the banner URL generated
+- 🎨 **Banner content** - Text and styling parameters (publicly displayed content only)
+- 💡 **Purpose** - Understand feature usage and popular banner styles to improve the service
+
+**Note:** All logs are ephemeral (console only, not stored in database). The content you generate is meant to be publicly displayed on GitHub, so logging helps improve the service without violating privacy.
+
 ### What We DON'T Track
 - ❌ No IP addresses
 - ❌ No personal information  
 - ❌ No user identities
 - ❌ No analytics or behavioral data
 - ❌ No cookies or tracking pixels
-- ❌ No timestamps or usage patterns
+- ❌ No session data or persistent storage
 
 ### Why Track (When Enabled)
 Understanding which repositories use this service helps:
@@ -150,7 +169,7 @@ Generate a custom SVG banner.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `header` | string | No | "Hello World" | Main text (supports emojis) |
+| `header` | string | No | "Hello World" | Main text (supports emojis and icons) |
 | `subheader` | string | No | - | Optional subtitle text |
 | `bg` | string | No | `1a1a1a-4a4a4a` | Background color in hex format |
 | `color` | string | No | `ffffff` | Header text color (hex without #) |
@@ -232,11 +251,33 @@ View repository tracking statistics (when enabled).
 
 The UI includes presets for quick access:
 
-**Gradients**: `1a1a1a-4a4a4a` (Midnight) • `ec4899-3b82f6` (Vibe) • `14b8a6-06b6d4` (Ocean) • `431586-9231A8` (Railway) 🆕 • `F38020-FBAB41` (Cloudflare) 🆕 • `E7F9FF-90C4E8` (OSSPH)
+### Gradients
 
-**Solids**: `fee2e2`/`bb2c2c` (Molty) • `fde8e3`/`de7356` (Claude) • `10a37f`/`ffffff` (GPT) • `f3f4f6`/`1f2937` (Minimal)
+| Name | Background | Text Color | Preview |
+|------|------------|------------|---------|
+| Midnight | `1a1a1a-4a4a4a` | `ffffff` | ![Midnight](https://ghrb.waren.build/banner?header=Midnight&bg=1a1a1a-4a4a4a&color=ffffff) |
+| Vibe | `ec4899-3b82f6` | `ffffff` | ![Vibe](https://ghrb.waren.build/banner?header=Vibe&bg=ec4899-3b82f6&color=ffffff) |
+| Ocean | `14b8a6-06b6d4` | `ffffff` | ![Ocean](https://ghrb.waren.build/banner?header=Ocean&bg=14b8a6-06b6d4&color=ffffff) |
+| Railway 🆕 | `431586-9231A8` | `ffffff` | ![Railway](https://ghrb.waren.build/banner?header=Railway&bg=431586-9231A8&color=ffffff) |
+| Cloudflare 🆕 | `F38020-FBAB41` | `ffffff` | ![Cloudflare](https://ghrb.waren.build/banner?header=Cloudflare&bg=F38020-FBAB41&color=ffffff) |
+| Waren 🆕 | `013B84-016EEA` | `ffffff` | ![Waren](https://ghrb.waren.build/banner?header=Waren&bg=013B84-016EEA&color=ffffff) |
+| OSSPH | `E7F9FF-90C4E8` | `0060A0` | ![OSSPH](https://ghrb.waren.build/banner?header=OSSPH&bg=E7F9FF-90C4E8&color=0060A0) |
 
-**Special**: `00000000`/`ffffff` (Transparent)
+### Solid Colors
+
+| Name | Background | Text Color | Preview |
+|------|------------|------------|---------|
+| Sky | `87ceeb` | `1e3a8a` | ![Sky](https://ghrb.waren.build/banner?header=Sky&bg=87ceeb&color=1e3a8a) |
+| Molty | `fee2e2` | `bb2c2c` | ![Molty](https://ghrb.waren.build/banner?header=Molty&bg=fee2e2&color=bb2c2c) |
+| Claude | `fde8e3` | `de7356` | ![Claude](https://ghrb.waren.build/banner?header=Claude&bg=fde8e3&color=de7356) |
+| GPT | `10a37f` | `ffffff` | ![GPT](https://ghrb.waren.build/banner?header=GPT&bg=10a37f&color=ffffff) |
+| Minimal | `f3f4f6` | `1f2937` | ![Minimal](https://ghrb.waren.build/banner?header=Minimal&bg=f3f4f6&color=1f2937) |
+
+### Special
+
+| Name | Background | Text Color | Preview |
+|------|------------|------------|---------|
+| Transparent | `00000000` | `ffffff` | ![Transparent](https://ghrb.waren.build/banner?header=Transparent&bg=00000000&color=ffffff) |
 
 > **Tip:** Create any custom gradient or color using hex codes directly in the URL.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@hono/node-server": "^1.13.0",
     "@wgtechlabs/log-engine": "^2.2.0",
     "dotenv": "^17.2.3",
-    "hono": "^4.7.0",
+    "hono": "^4.11.7",
     "ioredis": "^5.9.2"
   },
   "devDependencies": {
@@ -20,6 +20,9 @@
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": "^22"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
+    "@wgtechlabs/log-engine": "^2.2.0",
     "dotenv": "^17.2.3",
     "hono": "^4.7.0",
     "ioredis": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
+    "dotenv": "^17.2.3",
     "hono": "^4.7.0",
     "ioredis": "^5.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-repo-banner",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Generate customizable GitHub repository banners via URL parameters",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,17 +9,20 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@hono/node-server": "^1.13.0",
     "hono": "^4.7.0",
-    "@hono/node-server": "^1.13.0"
+    "ioredis": "^5.9.2"
   },
   "devDependencies": {
-    "typescript": "^5.7.0",
+    "@types/node": "^22.10.0",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",
-    "@types/node": "^22.10.0"
+    "typescript": "^5.7.0"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.0
         version: 1.19.9(hono@4.11.7)
+      '@wgtechlabs/log-engine':
+        specifier: ^2.2.0
+        version: 2.2.0
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -357,6 +360,10 @@ packages:
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
+  '@wgtechlabs/log-engine@2.2.0':
+    resolution: {integrity: sha512-TIvzfDPiWUWW7EX+kZ3q7id12inpe6t9n/OIX9ewIHaBeA7q8YY631f2RjHdkB33Wew9A0H1HGzTx98nKan+MQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -789,6 +796,8 @@ snapshots:
   '@types/node@22.19.7':
     dependencies:
       undici-types: 6.21.0
+
+  '@wgtechlabs/log-engine@2.2.0': {}
 
   acorn@8.15.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.13.0
         version: 1.19.9(hono@4.11.7)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
       hono:
         specifier: ^4.7.0
         version: 4.11.7
@@ -404,6 +407,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -811,6 +818,8 @@ snapshots:
       ms: 2.1.3
 
   denque@2.1.0: {}
+
+  dotenv@17.2.3: {}
 
   esbuild@0.27.2:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^17.2.3
         version: 17.2.3
       hono:
-        specifier: ^4.7.0
+        specifier: ^4.11.7
         version: 4.11.7
       ioredis:
         specifier: ^5.9.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.11.7
+      ioredis:
+        specifier: ^5.9.2
+        version: 5.9.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -191,6 +194,9 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -371,6 +377,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -390,6 +400,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -420,6 +434,10 @@ packages:
     resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
     engines: {node: '>=16.9.0'}
 
+  ioredis@5.9.2:
+    resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
+    engines: {node: '>=12.22.0'}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -434,6 +452,12 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -490,6 +514,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -505,6 +537,9 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -651,6 +686,8 @@ snapshots:
     dependencies:
       hono: 4.11.7
 
+  '@ioredis/commands@1.5.0': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -761,6 +798,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  cluster-key-slot@1.1.2: {}
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -770,6 +809,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  denque@2.1.0: {}
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -819,6 +860,20 @@ snapshots:
 
   hono@4.11.7: {}
 
+  ioredis@5.9.2:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   joycon@3.1.1: {}
 
   lilconfig@3.1.3: {}
@@ -826,6 +881,10 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   load-tsconfig@0.2.5: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -870,6 +929,12 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -906,6 +971,8 @@ snapshots:
       fsevents: 2.3.3
 
   source-map@0.7.6: {}
+
+  standard-as-callback@2.1.0: {}
 
   sucrase@3.35.1:
     dependencies:

--- a/src/banner/backgrounds.ts
+++ b/src/banner/backgrounds.ts
@@ -61,6 +61,16 @@ export const BACKGROUNDS: Record<string, BackgroundPreset> = {
     ],
     defaultTextColor: '#ffffff',
   },
+  'gradient-waren': {
+    id: 'gradient-waren',
+    name: 'Waren',
+    type: 'gradient',
+    stops: [
+      { offset: '0%', color: '#013b84' },
+      { offset: '100%', color: '#016eea' },
+    ],
+    defaultTextColor: '#ffffff',
+  },
   'solid-lightblue': {
     id: 'solid-lightblue',
     name: 'Sky',

--- a/src/banner/backgrounds.ts
+++ b/src/banner/backgrounds.ts
@@ -41,6 +41,26 @@ export const BACKGROUNDS: Record<string, BackgroundPreset> = {
     ],
     defaultTextColor: '#0060A0',
   },
+  'gradient-railway': {
+    id: 'gradient-railway',
+    name: 'Railway',
+    type: 'gradient',
+    stops: [
+      { offset: '0%', color: '#431586' },
+      { offset: '100%', color: '#9231A8' },
+    ],
+    defaultTextColor: '#ffffff',
+  },
+  'gradient-cloudflare': {
+    id: 'gradient-cloudflare',
+    name: 'Cloudflare',
+    type: 'gradient',
+    stops: [
+      { offset: '0%', color: '#F38020' },
+      { offset: '100%', color: '#FBAB41' },
+    ],
+    defaultTextColor: '#ffffff',
+  },
   'solid-lightblue': {
     id: 'solid-lightblue',
     name: 'Sky',

--- a/src/banner/icons.ts
+++ b/src/banner/icons.ts
@@ -250,12 +250,9 @@ export async function renderSegmentsAsHTML(
       if (iconTheme === 'light') {
         // Light background needs dark icon for contrast
         iconColor = '000000';
-      } else if (iconTheme === 'dark') {
+      } else {
         // Dark background needs light icon for contrast
         iconColor = 'ffffff';
-      } else {
-        // Auto mode: use text color for consistency
-        iconColor = textColor.replace('#', '');
       }
 
       // Fetch Simple Icon SVG

--- a/src/banner/icons.ts
+++ b/src/banner/icons.ts
@@ -267,10 +267,9 @@ export async function renderSegmentsAsHTML(
         parts.push(
           `<img src="data:image/svg+xml;base64,${base64}" style="display:inline-block;width:${fontSize}px;height:${fontSize}px;vertical-align:middle;margin:0 0.1em;" alt="" />`,
         );
-      } else {
-        // Fallback: render as text in brackets if icon not found
-        parts.push(`[${escapeXml(segment.value)}]`);
       }
+      // If icon not found, don't render anything (silent fail)
+      // This gives users feedback that the icon name is invalid
     }
   }
 

--- a/src/banner/icons.ts
+++ b/src/banner/icons.ts
@@ -1,0 +1,278 @@
+import type { HeaderSegment, BackgroundPreset } from './types.js';
+import { emojiToCodepoint, fetchTwemojiSVG } from './emoji.js';
+import { escapeXml, sanitizeIconSlug } from '../utils/sanitize.js';
+
+// In-memory cache for fetched Simple Icons SVGs
+const iconCache = new Map<string, string>();
+
+// Regex to match icon syntax: ![slug] or ![slug](theme)
+const ICON_RE = /!\[([a-z0-9-]+)\](?:\((light|dark|auto)\))?/g;
+
+// Regex to detect emojis (same as in emoji.ts)
+const EMOJI_RE =
+  /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(\u200D(\p{Emoji_Presentation}|\p{Emoji}\uFE0F))*/gu;
+
+/**
+ * Fetch a Simple Icons SVG from CDN with specified color
+ * @param slug Icon slug (e.g., 'github', 'react')
+ * @param color Hex color without # (e.g., 'ffffff')
+ * @returns SVG string or null if not found
+ */
+export async function fetchSimpleIconSVG(
+  slug: string,
+  color: string,
+): Promise<string | null> {
+  // Sanitize the slug to ensure it's valid
+  const cleanSlug = sanitizeIconSlug(slug);
+  if (!cleanSlug) return null;
+
+  const cacheKey = `${cleanSlug}-${color}`;
+
+  if (iconCache.has(cacheKey)) {
+    return iconCache.get(cacheKey)!;
+  }
+
+  const url = `https://cdn.simpleicons.org/${cleanSlug}/${color}`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const svg = await res.text();
+    iconCache.set(cacheKey, svg);
+    return svg;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculate relative luminance of a color (WCAG 2.0 formula)
+ * Returns value between 0 (black) and 1 (white)
+ * @param hexColor Hex color string (with or without #, supports 6 and 8 char formats)
+ */
+export function calculateLuminance(hexColor: string): number {
+  // Remove # if present
+  const hex = hexColor.replace('#', '');
+
+  // Parse RGB values (handle both 6 and 8 char hex, ignore alpha if present)
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  // Apply gamma correction (linearize RGB values)
+  const linearize = (c: number) =>
+    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+
+  const R = linearize(r);
+  const G = linearize(g);
+  const B = linearize(b);
+
+  // Calculate relative luminance using WCAG formula
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+/**
+ * Determine if a background is light or dark for auto theme selection
+ * @param background The background preset to analyze
+ * @returns 'light' if background is light (needs dark icons), 'dark' if dark (needs light icons)
+ */
+export function detectBackgroundTheme(
+  background: BackgroundPreset,
+): 'light' | 'dark' {
+  if (background.type === 'transparent') {
+    // Assume transparent = light background (common for GitHub READMEs)
+    return 'light';
+  }
+
+  if (background.type === 'solid' && background.color) {
+    const luminance = calculateLuminance(background.color);
+    // Threshold: 0.5 is middle gray
+    return luminance > 0.5 ? 'light' : 'dark';
+  }
+
+  // Gradient: average the luminance of all stop colors
+  if (background.type === 'gradient' && background.stops) {
+    const luminances = background.stops.map((stop) =>
+      calculateLuminance(stop.color),
+    );
+    const avgLuminance =
+      luminances.reduce((a, b) => a + b, 0) / luminances.length;
+    return avgLuminance > 0.5 ? 'light' : 'dark';
+  }
+
+  // Fallback to dark
+  return 'dark';
+}
+
+/**
+ * Parse header string into segments of text, emoji, and icons
+ * This function combines both emoji and icon detection
+ * @param header The header text to parse
+ * @returns Array of segments in order
+ */
+export function parseHeaderWithIcons(header: string): HeaderSegment[] {
+  if (!header) return [];
+
+  const segments: HeaderSegment[] = [];
+
+  // First, we need to identify all icons and their positions
+  const iconMatches: Array<{
+    index: number;
+    length: number;
+    slug: string;
+    theme: 'light' | 'dark' | 'auto';
+  }> = [];
+
+  for (const match of header.matchAll(ICON_RE)) {
+    iconMatches.push({
+      index: match.index!,
+      length: match[0].length,
+      slug: match[1],
+      theme: (match[2] as 'light' | 'dark' | 'auto') || 'auto',
+    });
+  }
+
+  // Process the text, splitting by icons
+  let lastIndex = 0;
+
+  for (const iconMatch of iconMatches) {
+    // Process text before this icon (which may contain emoji)
+    if (iconMatch.index > lastIndex) {
+      const textBefore = header.slice(lastIndex, iconMatch.index);
+      if (textBefore) {
+        const emojiSegments = parseEmojiInText(textBefore);
+        segments.push(...emojiSegments);
+      }
+    }
+
+    // Add icon segment
+    segments.push({
+      type: 'icon',
+      value: iconMatch.slug,
+      theme: iconMatch.theme,
+    });
+
+    lastIndex = iconMatch.index + iconMatch.length;
+  }
+
+  // Add remaining text after last icon
+  if (lastIndex < header.length) {
+    const remainingText = header.slice(lastIndex);
+    if (remainingText) {
+      const emojiSegments = parseEmojiInText(remainingText);
+      segments.push(...emojiSegments);
+    }
+  }
+
+  // If no segments found, treat whole header as text
+  if (segments.length === 0 && header.length > 0) {
+    segments.push({ type: 'text', value: header });
+  }
+
+  return segments;
+}
+
+/**
+ * Helper to parse emoji within text
+ * Splits text into text and emoji segments
+ */
+function parseEmojiInText(text: string): HeaderSegment[] {
+  const segments: HeaderSegment[] = [];
+  let lastIdx = 0;
+
+  for (const match of text.matchAll(EMOJI_RE)) {
+    // Add text before this emoji
+    if (match.index! > lastIdx) {
+      segments.push({ type: 'text', value: text.slice(lastIdx, match.index!) });
+    }
+    // Add emoji
+    segments.push({ type: 'emoji', value: match[0] });
+    lastIdx = match.index! + match[0].length;
+  }
+
+  // Add remaining text
+  if (lastIdx < text.length) {
+    segments.push({ type: 'text', value: text.slice(lastIdx) });
+  }
+
+  // If no segments, treat entire text as text segment
+  if (segments.length === 0 && text.length > 0) {
+    segments.push({ type: 'text', value: text });
+  }
+
+  return segments;
+}
+
+/**
+ * Render segments (text/emoji/icons) as HTML
+ * @param segments Array of segments to render
+ * @param fontSize Font size in pixels for inline images
+ * @param textColor Text color (hex with #) to use for icons
+ * @param backgroundTheme The detected background theme (for auto icons)
+ * @returns HTML string with inline images for emoji and icons
+ */
+export async function renderSegmentsAsHTML(
+  segments: HeaderSegment[],
+  fontSize: number,
+  textColor: string,
+  backgroundTheme: 'light' | 'dark',
+): Promise<string> {
+  const parts: string[] = [];
+
+  for (const segment of segments) {
+    if (segment.type === 'text') {
+      // XML-escape text and render directly
+      parts.push(escapeXml(segment.value));
+    } else if (segment.type === 'emoji') {
+      // Fetch Twemoji SVG and render as inline image
+      const codepoint = emojiToCodepoint(segment.value);
+      const svgData = await fetchTwemojiSVG(codepoint);
+
+      if (svgData) {
+        // Convert to base64 and render as inline img
+        const base64 = Buffer.from(svgData).toString('base64');
+        parts.push(
+          `<img src="data:image/svg+xml;base64,${base64}" style="display:inline-block;width:${fontSize}px;height:${fontSize}px;vertical-align:middle;margin:0 0.1em;" alt="" />`,
+        );
+      } else {
+        // Fallback to text if emoji fetch fails
+        parts.push(escapeXml(segment.value));
+      }
+    } else if (segment.type === 'icon') {
+      // Determine the theme to use for this icon
+      const iconTheme =
+        segment.theme === 'auto' ? backgroundTheme : segment.theme!;
+
+      // Get color for icon based on theme
+      // 'light' theme = icon for light background = dark icon
+      // 'dark' theme = icon for dark background = light icon
+      let iconColor: string;
+      if (iconTheme === 'light') {
+        // Light background needs dark icon for contrast
+        iconColor = '000000';
+      } else if (iconTheme === 'dark') {
+        // Dark background needs light icon for contrast
+        iconColor = 'ffffff';
+      } else {
+        // Auto mode: use text color for consistency
+        iconColor = textColor.replace('#', '');
+      }
+
+      // Fetch Simple Icon SVG
+      const svgData = await fetchSimpleIconSVG(segment.value, iconColor);
+
+      if (svgData) {
+        // Convert to base64 and render as inline img
+        const base64 = Buffer.from(svgData).toString('base64');
+        parts.push(
+          `<img src="data:image/svg+xml;base64,${base64}" style="display:inline-block;width:${fontSize}px;height:${fontSize}px;vertical-align:middle;margin:0 0.1em;" alt="" />`,
+        );
+      } else {
+        // Fallback: render as text in brackets if icon not found
+        parts.push(`[${escapeXml(segment.value)}]`);
+      }
+    }
+  }
+
+  return parts.join('');
+}

--- a/src/banner/icons.ts
+++ b/src/banner/icons.ts
@@ -268,8 +268,8 @@ export async function renderSegmentsAsHTML(
           `<img src="data:image/svg+xml;base64,${base64}" style="display:inline-block;width:${fontSize}px;height:${fontSize}px;vertical-align:middle;margin:0 0.1em;" alt="" />`,
         );
       }
-      // If icon not found, don't render anything (silent fail)
-      // This gives users feedback that the icon name is invalid
+      // If icon fetch fails, skip it silently and continue rendering other segments
+      // This prevents invalid icons from breaking the layout or hiding subsequent text
     }
   }
 

--- a/src/banner/svg-template.ts
+++ b/src/banner/svg-template.ts
@@ -1,9 +1,14 @@
 import type { BannerOptions, BackgroundPreset } from './types.js';
 import { escapeXml } from '../utils/sanitize.js';
+import {
+  detectBackgroundTheme,
+  parseHeaderWithIcons,
+  renderSegmentsAsHTML,
+} from './icons.js';
 
 const WIDTH = 1280;
 const HEIGHT = 304;
-const MARGIN = 100;
+const MARGIN = 50;
 const MAX_CONTENT_WIDTH = WIDTH - MARGIN * 2;
 const BASE_FONT_SIZE = 192;
 const MIN_FONT_SIZE = 24;
@@ -127,7 +132,6 @@ async function buildGoogleFontsStyle(headerFont?: string, subheaderFont?: string
       },
     });
     if (!response.ok) {
-      console.error('Google Fonts fetch failed:', response.status);
       return '';
     }
 
@@ -175,38 +179,34 @@ async function buildGoogleFontsStyle(headerFont?: string, subheaderFont?: string
 
 /**
  * Estimate text width for font sizing decisions.
- * Properly accounts for emojis which render wider than text.
+ * Properly accounts for emojis and icons which render wider than text.
  */
 function estimateTextWidth(text: string, fontSize: number): number {
   // Regex to detect emojis (including multi-codepoint sequences)
   const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(\u200D(\p{Emoji_Presentation}|\p{Emoji}\uFE0F))*/gu;
-  
+  // Regex to detect icons: ![slug] or ![slug](theme)
+  const iconRegex = /!\[([a-z0-9-]+)\](?:\((light|dark|auto)\))?/g;
+
+  // Count icons and emojis to add their width
+  const iconCount = (text.match(iconRegex) || []).length;
+  const emojiCount = (text.match(emojiRegex) || []).length;
+
+  // Remove icons and emojis from text for accurate character width calculation
+  let cleanText = text.replace(iconRegex, '').replace(emojiRegex, '');
+
   let width = 0;
-  let lastIndex = 0;
-  
-  // Process emojis
-  for (const match of text.matchAll(emojiRegex)) {
-    // Add text before this emoji
-    if (match.index! > lastIndex) {
-      const textBefore = text.slice(lastIndex, match.index!);
-      for (const ch of textBefore) {
-        width += fontSize * (ch === ' ' ? SPACE_WIDTH_RATIO : CHAR_WIDTH_RATIO);
-      }
-    }
-    
-    // Add emoji width
-    width += fontSize * EMOJI_WIDTH_RATIO;
-    lastIndex = match.index! + match[0].length;
+
+  // Calculate width of regular text
+  for (const ch of cleanText) {
+    width += fontSize * (ch === ' ' ? SPACE_WIDTH_RATIO : CHAR_WIDTH_RATIO);
   }
-  
-  // Add remaining text after last emoji
-  if (lastIndex < text.length) {
-    const remainingText = text.slice(lastIndex);
-    for (const ch of remainingText) {
-      width += fontSize * (ch === ' ' ? SPACE_WIDTH_RATIO : CHAR_WIDTH_RATIO);
-    }
-  }
-  
+
+  // Add width for icons and emojis
+  // Each icon/emoji is rendered as fontSize width + 0.2em margin (0.1em on each side)
+  // EMOJI_WIDTH_RATIO already accounts for the visual size, add extra for margins
+  const marginWidth = fontSize * 0.2; // 0.1em on each side
+  width += (iconCount + emojiCount) * (fontSize * EMOJI_WIDTH_RATIO + marginWidth);
+
   return width;
 }
 
@@ -276,18 +276,44 @@ export async function buildBannerSVG(options: BannerOptions): Promise<string> {
   // Fetch and embed Google Fonts CSS if needed
   const googleFontsStyle = await buildGoogleFontsStyle(headerFont, subheaderFont);
 
-  // Use foreignObject with HTML — browser renders text + emoji natively
+  // Detect background theme for auto icon coloring
+  const backgroundTheme = detectBackgroundTheme(background);
+
+  // Parse header and subheader into segments (text, emoji, icons)
+  const headerSegments = parseHeaderWithIcons(header);
+  const subheaderSegments = hasSubheader
+    ? parseHeaderWithIcons(subheader!)
+    : [];
+
+  // Use foreignObject with HTML — browser renders text + emoji + icons natively
   const subColorValue = subheaderColor || textColor;
+
+  // Render segments as HTML with inline images for emoji and icons
+  const headerHTML = await renderSegmentsAsHTML(
+    headerSegments,
+    effHeaderSize,
+    textColor,
+    backgroundTheme,
+  );
+
+  const subheaderHTML = hasSubheader
+    ? await renderSegmentsAsHTML(
+        subheaderSegments,
+        effSubSize,
+        subColorValue,
+        backgroundTheme,
+      )
+    : '';
 
   const htmlContent = hasSubheader
     ? `<div xmlns="http://www.w3.org/1999/xhtml" style="width:${WIDTH}px;height:${HEIGHT}px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:${VERTICAL_PAD}px ${MARGIN}px;box-sizing:border-box;">
   ${googleFontsStyle}
-  <div style="font-family:${escapeXml(headerFontFamily)};font-size:${effHeaderSize}px;font-weight:700;color:${textColor};line-height:1;text-align:center;white-space:nowrap;">${escapeXml(header)}</div>
-  <div style="font-family:${escapeXml(subheaderFontFamily)};font-size:${effSubSize}px;font-weight:400;color:${subColorValue};line-height:1;text-align:center;white-space:nowrap;margin-top:${effGap}px;">${escapeXml(subheader!)}</div>
+  <div style="font-family:${escapeXml(headerFontFamily)};font-size:${effHeaderSize}px;font-weight:700;color:${textColor};line-height:1;text-align:center;white-space:nowrap;">${headerHTML}</div>
+  <div style="font-family:${escapeXml(subheaderFontFamily)};font-size:${effSubSize}px;font-weight:400;color:${subColorValue};line-height:1;text-align:center;white-space:nowrap;margin-top:${effGap}px;">${subheaderHTML}</div>
 </div>`
     : `<div xmlns="http://www.w3.org/1999/xhtml" style="width:${WIDTH}px;height:${HEIGHT}px;display:flex;align-items:center;justify-content:center;padding:0 ${MARGIN}px;box-sizing:border-box;">
   ${googleFontsStyle}
-  <div style="font-family:${escapeXml(headerFontFamily)};font-size:${effHeaderSize}px;font-weight:700;color:${textColor};line-height:1;text-align:center;white-space:nowrap;">${escapeXml(header)}</div>
+  <div style="font-family:${escapeXml(headerFontFamily)};font-size:${effHeaderSize}px;font-weight:700;color:${textColor};line-height:1;text-align:center;white-space:nowrap;">${headerHTML}</div>
 </div>`;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}">

--- a/src/banner/svg-template.ts
+++ b/src/banner/svg-template.ts
@@ -29,7 +29,7 @@ function buildBackground(bg: BackgroundPreset): string {
 }
 
 function buildWatermark(position: string = 'bottom-right'): string {
-  const text = 'made with ghrb.waren.build';
+  const text = 'ghrb.waren.build';
   const fontSize = 16;
   const rectPaddingX = 8;
   const rectPaddingY = 6;
@@ -120,8 +120,6 @@ async function buildGoogleFontsStyle(headerFont?: string, subheaderFont?: string
 
     const fontUrl = `https://fonts.googleapis.com/css2?${fontFamilies}&display=swap`;
 
-    console.log('Fetching Google Fonts:', fontUrl);
-
     // Fetch the CSS with a browser User-Agent to get woff2 format (smaller files)
     const response = await fetch(fontUrl, {
       headers: {
@@ -134,7 +132,6 @@ async function buildGoogleFontsStyle(headerFont?: string, subheaderFont?: string
     }
 
     let css = await response.text();
-    console.log('Google Fonts CSS length:', css.length);
 
     // Extract all external font url() references and replace with inline base64 data URIs
     // This makes the SVG self-contained so fonts work everywhere

--- a/src/banner/types.ts
+++ b/src/banner/types.ts
@@ -8,8 +8,10 @@ export interface BackgroundPreset {
 }
 
 export interface HeaderSegment {
-  type: 'text' | 'emoji';
+  type: 'text' | 'emoji' | 'icon';
   value: string;
+  /** Theme for icons (auto, light, or dark) */
+  theme?: 'light' | 'dark' | 'auto';
   /** Width in SVG units — computed during rendering */
   width?: number;
 }

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,0 +1,82 @@
+import Redis from 'ioredis';
+
+let redisClient: Redis | null = null;
+let statsEnabled = false;
+
+/**
+ * Initialize Redis connection if stats tracking is enabled
+ * @returns Promise<void>
+ */
+export async function initRedis(): Promise<void> {
+  const enableStats = process.env.ENABLE_STATS === 'true';
+  const redisUrl = process.env.REDIS_URL;
+
+  if (!enableStats) {
+    console.log('📊 Stats tracking: DISABLED (privacy-first default)');
+    statsEnabled = false;
+    return;
+  }
+
+  if (!redisUrl) {
+    console.warn('⚠️  Stats tracking enabled but REDIS_URL not configured. Stats will be disabled.');
+    statsEnabled = false;
+    return;
+  }
+
+  try {
+    redisClient = new Redis(redisUrl, {
+      maxRetriesPerRequest: 3,
+      retryStrategy(times) {
+        if (times > 3) {
+          console.error('❌ Redis connection failed after 3 retries. Stats tracking disabled.');
+          return null; // Stop retrying
+        }
+        const delay = Math.min(times * 100, 2000);
+        return delay;
+      },
+      reconnectOnError(err) {
+        console.error('Redis connection error:', err.message);
+        return false; // Don't reconnect on error
+      },
+    });
+
+    // Test connection
+    await redisClient.ping();
+    statsEnabled = true;
+    console.log('📊 Stats tracking: ENABLED');
+    console.log('   - Repository tracking active');
+    console.log('   - View stats at: /stats');
+  } catch (error) {
+    console.error('❌ Redis connection failed:', error instanceof Error ? error.message : 'Unknown error');
+    console.log('   - Stats tracking disabled');
+    statsEnabled = false;
+    redisClient = null;
+  }
+}
+
+/**
+ * Get Redis client instance
+ * @returns Redis client or null if not initialized
+ */
+export function getRedis(): Redis | null {
+  return redisClient;
+}
+
+/**
+ * Check if stats tracking is enabled and Redis is connected
+ * @returns boolean
+ */
+export function isStatsEnabled(): boolean {
+  return statsEnabled && redisClient !== null;
+}
+
+/**
+ * Gracefully close Redis connection
+ */
+export async function closeRedis(): Promise<void> {
+  if (redisClient) {
+    await redisClient.quit();
+    redisClient = null;
+    statsEnabled = false;
+  }
+}

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -50,6 +50,9 @@ export async function initRedis(): Promise<void> {
     console.error('❌ Redis connection failed:', error instanceof Error ? error.message : 'Unknown error');
     console.log('   - Stats tracking disabled');
     statsEnabled = false;
+    if (redisClient) {
+      await redisClient.quit().catch(() => {});
+    }
     redisClient = null;
   }
 }
@@ -75,7 +78,7 @@ export function isStatsEnabled(): boolean {
  */
 export async function closeRedis(): Promise<void> {
   if (redisClient) {
-    await redisClient.quit();
+    await redisClient.quit().catch(() => {});
     redisClient = null;
     statsEnabled = false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,43 @@ import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import bannerRoute from './routes/banner.js';
 import uiRoute from './routes/ui.js';
+import statsRoute from './routes/stats.js';
+import { initRedis, isStatsEnabled } from './config/redis.js';
 
 const app = new Hono();
 
 // Health check endpoint for Railway
 app.get('/health', (c) => {
-  return c.json({ status: 'ok', timestamp: new Date().toISOString() });
+  const health: {
+    status: string;
+    timestamp: string;
+    stats: {
+      enabled: boolean;
+      endpoint?: string;
+    };
+  } = {
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    stats: {
+      enabled: isStatsEnabled(),
+    },
+  };
+
+  if (isStatsEnabled()) {
+    health.stats.endpoint = '/stats';
+  }
+
+  return c.json(health);
 });
 
 app.route('/', uiRoute);
 app.route('/', bannerRoute);
+app.route('/', statsRoute);
 
 const port = parseInt(process.env.PORT || '3000', 10);
+
+// Initialize Redis before starting server
+await initRedis();
 
 serve({ fetch: app.fetch, port }, (info) => {
   console.log(`Banner server running at http://localhost:${info.port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 import 'dotenv/config';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
+import { LogEngine, LogMode } from '@wgtechlabs/log-engine';
 import bannerRoute from './routes/banner.js';
 import uiRoute from './routes/ui.js';
 import statsRoute from './routes/stats.js';
 import { initRedis, isStatsEnabled } from './config/redis.js';
+
+// Configure log-engine based on environment
+const env = process.env.NODE_ENV || 'development';
+LogEngine.configure({ 
+  mode: env === 'production' ? LogMode.INFO : LogMode.DEBUG 
+});
 
 const app = new Hono();
 
@@ -42,5 +49,12 @@ const port = parseInt(process.env.PORT || '3000', 10);
 await initRedis();
 
 serve({ fetch: app.fetch, port }, (info) => {
-  console.log(`Banner server running at http://localhost:${info.port}`);
+  LogEngine.info('='.repeat(50));
+  LogEngine.info('GitHub Repo Banner Service');
+  LogEngine.info('📦 Version: 1.2.0');
+  LogEngine.info('👤 Author: Waren Gonzaga');
+  LogEngine.info('='.repeat(50));
+  LogEngine.info(`🚀 Server: http://localhost:${info.port}`);
+  LogEngine.info(`📊 Stats: ${isStatsEnabled() ? 'Enabled (/stats)' : 'Disabled'}`);
+  LogEngine.info('='.repeat(50));
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import bannerRoute from './routes/banner.js';

--- a/src/routes/banner.ts
+++ b/src/routes/banner.ts
@@ -12,9 +12,15 @@ bannerRoute.get('/banner', async (c) => {
 
   if (repoMatch && isStatsEnabled()) {
     const repo = repoMatch[1];
-    const redis = getRedis();
-    // Fire and forget - don't block banner generation
-    redis?.sadd('repos:tracked', repo).catch(() => {});
+    // Skip obvious non-repo paths
+    const nonRepoPrefixes = ['settings', 'orgs', 'users', 'explore', 'notifications', 'issues', 'pulls'];
+    const isNonRepoPath = nonRepoPrefixes.some(p => repo.startsWith(p + '/') || repo === p);
+    
+    if (!isNonRepoPath) {
+      const redis = getRedis();
+      // Fire and forget - don't block banner generation
+      redis?.sadd('repos:tracked', repo).catch(() => {});
+    }
   }
 
   const rawHeader = c.req.query('header') || 'Hello World';

--- a/src/routes/banner.ts
+++ b/src/routes/banner.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { buildBannerSVG } from '../banner/svg-template.js';
 import { sanitizeHeader, sanitizeFontName, isValidHexColor } from '../utils/sanitize.js';
 import { getRedis, isStatsEnabled } from '../config/redis.js';
+import { LogEngine } from '@wgtechlabs/log-engine';
 
 const bannerRoute = new Hono();
 
@@ -19,7 +20,9 @@ bannerRoute.get('/banner', async (c) => {
     if (!isNonRepoPath) {
       const redis = getRedis();
       // Fire and forget - don't block banner generation
-      redis?.sadd('repos:tracked', repo).catch(() => {});
+      redis?.sadd('repos:tracked', repo).then(() => {
+        LogEngine.log(`📊 Repository using banner: ${repo}`);
+      }).catch(() => {});
     }
   }
 

--- a/src/routes/banner.ts
+++ b/src/routes/banner.ts
@@ -1,10 +1,22 @@
 import { Hono } from 'hono';
 import { buildBannerSVG } from '../banner/svg-template.js';
 import { sanitizeHeader, sanitizeFontName, isValidHexColor } from '../utils/sanitize.js';
+import { getRedis, isStatsEnabled } from '../config/redis.js';
 
 const bannerRoute = new Hono();
 
 bannerRoute.get('/banner', async (c) => {
+  // Track repository usage if stats enabled
+  const referer = c.req.header('referer') || '';
+  const repoMatch = referer.match(/github\.com\/([^\/]+\/[^\/]+)(?:\/|$)/);
+
+  if (repoMatch && isStatsEnabled()) {
+    const repo = repoMatch[1];
+    const redis = getRedis();
+    // Fire and forget - don't block banner generation
+    redis?.sadd('repos:tracked', repo).catch(() => {});
+  }
+
   const rawHeader = c.req.query('header') || 'Hello World';
   const rawSubheader = c.req.query('subheader') || '';
   const bgParam = c.req.query('bg') || '1a1a1a-4a4a4a'; // Default gradient

--- a/src/routes/banner.ts
+++ b/src/routes/banner.ts
@@ -100,7 +100,7 @@ bannerRoute.get('/banner', async (c) => {
       ? `#${subheaderColorParam}`
       : undefined;
 
-  const showWatermark = supportParam === 'true';
+  const showWatermark = supportParam !== 'false';
   
   // Validate watermark position
   const validPositions = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,45 @@
+import { Hono } from 'hono';
+import { getRedis, isStatsEnabled } from '../config/redis.js';
+
+const statsRoute = new Hono();
+
+statsRoute.get('/stats', async (c) => {
+  if (!isStatsEnabled()) {
+    return c.json({
+      enabled: false,
+      message: 'Stats tracking is disabled',
+    });
+  }
+
+  try {
+    const redis = getRedis();
+    if (!redis) {
+      return c.json({
+        enabled: false,
+        message: 'Stats tracking is disabled',
+      });
+    }
+
+    const repositories = await redis.smembers('repos:tracked');
+    const totalRepositories = repositories.length;
+
+    return c.json({
+      enabled: true,
+      totalRepositories,
+      repositories: repositories.sort(),
+      note: 'Only tracking public GitHub repositories using this service',
+    });
+  } catch (error) {
+    console.error('Error fetching stats:', error);
+    return c.json(
+      {
+        enabled: true,
+        error: 'Failed to fetch stats',
+        message: 'Redis connection issue',
+      },
+      500
+    );
+  }
+});
+
+export default statsRoute;

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { getRedis, isStatsEnabled } from '../config/redis.js';
+import { LogEngine } from '@wgtechlabs/log-engine';
 
 const statsRoute = new Hono();
 
@@ -39,6 +40,25 @@ statsRoute.get('/stats', async (c) => {
       },
       500
     );
+  }
+});
+
+statsRoute.post('/log', async (c) => {
+  try {
+    const body = await c.req.json();
+    const { action, url } = body;
+    
+    if (!action) {
+      return c.json({ error: 'Action is required' }, 400);
+    }
+    
+    // Log user action to server console
+    LogEngine.log(`📊 User Action: ${action} | URL: ${url || 'N/A'}`);
+    
+    return c.json({ success: true });
+  } catch (error) {
+    LogEngine.error('Error logging user action:', error instanceof Error ? error.message : 'Unknown error');
+    return c.json({ error: 'Failed to log action' }, 500);
   }
 });
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -328,8 +328,8 @@
       padding: 10px 14px;
       font-size: 0.75rem;
       white-space: pre-line;
-      min-width: 200px;
-      max-width: 500px;
+      width: max-content;
+      max-width: 600px;
       z-index: 10000;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
       opacity: 0;

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1542,10 +1542,10 @@
       <div class="sidebar-section">
         <h2>🔒 Privacy Notice</h2>
         <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590; margin-bottom: 0.75rem;">
-          This service logs button clicks and generated banner URLs to improve features. All content is meant to be publicly displayed on GitHub.
+          This service logs button clicks and generated banner URLs via the <code>/log</code> handler (console only) to improve features. When <code>ENABLE_STATS</code> is enabled, the <code>/banner</code> endpoint also stores repository names in Redis for usage statistics—<strong>not user identities or IPs</strong>. All content is meant to be publicly displayed on GitHub.
         </p>
         <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590;">
-          We <strong>don't track</strong> IPs, personal info, or user identities. Logs are ephemeral (console only). 
+          We <strong>don't track</strong> IPs, personal info, or user identities. Console logs are ephemeral; Redis stores only repository names for optional stats tracking. 
           <a href="https://github.com/warengonzaga/github-repo-banner#-privacy--transparency" target="_blank" rel="noopener" style="color: #58a6ff;">Learn more</a>
         </p>
       </div>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1050,7 +1050,7 @@
         <div class="form-group">
           <label for="header">Header Text</label>
           <div class="input-with-info">
-            <input type="text" id="header" value="Hello World 👋" placeholder="Enter your repository title or project name" maxlength="50" />
+            <input type="text" id="header" value="![github] Hello World 👋" placeholder="Enter your repository title or project name" maxlength="50" />
             <button type="button" class="info-icon-btn" id="header-info-btn" aria-label="Show emoji and icon help">
               <svg viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
@@ -1146,30 +1146,6 @@
         </div>
 
         <div class="form-group">
-          <label for="bg-input">Background Color</label>
-          <div class="color-row">
-            <div class="hex-input-group">
-              <span class="hex-prefix">#</span>
-              <input type="text" id="bg-input" value="1A1A1A" placeholder="000000" maxlength="8" />
-            </div>
-            <span class="color-preview" id="bg-preview" title="Click to open color picker"></span>
-            <input type="color" id="bg-picker" class="color-picker-input" />
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label for="bg-input-2">Background Color 2 (optional for gradient)</label>
-          <div class="color-row">
-            <div class="hex-input-group">
-              <span class="hex-prefix">#</span>
-              <input type="text" id="bg-input-2" value="4A4A4A" placeholder="FFFFFF" maxlength="8" />
-            </div>
-            <span class="color-preview" id="bg-preview-2" title="Click to open color picker"></span>
-            <input type="color" id="bg-picker-2" class="color-picker-input" />
-          </div>
-        </div>
-
-        <div class="form-group">
           <label for="color-input">Header Text Color</label>
           <div class="color-row">
             <div class="hex-input-group">
@@ -1191,6 +1167,33 @@
             <span class="color-preview" id="subheader-color-preview" title="Click to open color picker"></span>
             <input type="color" id="subheader-color-picker" class="color-picker-input" />
           </div>
+        </div>
+
+        <div class="form-group">
+          <label for="bg-input">Primary Background Color</label>
+          <div class="color-row">
+            <div class="hex-input-group">
+              <span class="hex-prefix">#</span>
+              <input type="text" id="bg-input" value="1A1A1A" placeholder="000000" maxlength="8" />
+            </div>
+            <span class="color-preview" id="bg-preview" title="Click to open color picker"></span>
+            <input type="color" id="bg-picker" class="color-picker-input" />
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="bg-input-2">Secondary Background Color</label>
+          <div class="color-row">
+            <div class="hex-input-group">
+              <span class="hex-prefix">#</span>
+              <input type="text" id="bg-input-2" value="4A4A4A" placeholder="FFFFFF" maxlength="8" />
+            </div>
+            <span class="color-preview" id="bg-preview-2" title="Click to open color picker"></span>
+            <input type="color" id="bg-picker-2" class="color-picker-input" />
+          </div>
+          <p style="font-size: 0.75rem; color: #7d8590; margin-top: 0.5rem;">
+            Leave empty for solid background color.
+          </p>
         </div>
         </div>
 
@@ -1616,7 +1619,7 @@
 
     function buildUrl() {
       const params = new URLSearchParams();
-      const header = headerInput.value || 'Hello World 👋';
+      const header = headerInput.value || '![github] Hello World 👋';
       params.set('header', header);
       const subheader = subheaderInput.value.trim();
       if (subheader) {
@@ -1836,7 +1839,7 @@
 
     resetBtn.addEventListener('click', () => {
       // Reset all form fields to defaults
-      headerInput.value = 'Hello World 👋';
+      headerInput.value = '![github] Hello World 👋';
       subheaderInput.value = 'Great projects deserve great repository banners';
       headerFontInput.value = 'Permanent Marker';
       subheaderFontInput.value = 'Kinewave';
@@ -1890,7 +1893,7 @@
     copyUrlBtn.addEventListener('click', () => {
       // Build URL without support parameter
       const params = new URLSearchParams();
-      const header = headerInput.value || 'Hello World 👋';
+      const header = headerInput.value || '![github] Hello World 👋';
       params.set('header', header);
       const subheader = subheaderInput.value.trim();
       if (subheader) {

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1516,7 +1516,7 @@
 
     <aside class="sidebar">
       <div class="sidebar-section">
-        <h2>Author</h2>
+        <h2>☕ Author</h2>
         <a href="https://github.com/warengonzaga" target="_blank" rel="noopener" class="author-card">
           <img src="https://github.com/warengonzaga.png" alt="Waren Gonzaga" class="author-avatar">
           <div class="author-info">
@@ -1542,16 +1542,16 @@
       <div class="sidebar-section">
         <h2>🔒 Privacy Notice</h2>
         <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590; margin-bottom: 0.75rem;">
-          This service logs button clicks and generated banner URLs via the <code>/log</code> handler (console only) to improve features. When <code>ENABLE_STATS</code> is enabled, the <code>/banner</code> endpoint also stores repository names in Redis for usage statistics—<strong>not user identities or IPs</strong>. All content is meant to be publicly displayed on GitHub.
+          This service logs button clicks and banner URLs to improve features (console only). When <code>ENABLE_STATS</code> is enabled, repository names are stored in Redis for usage statistics. <strong>No IPs, personal info, or user identities are tracked.</strong>
         </p>
         <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590;">
-          We <strong>don't track</strong> IPs, personal info, or user identities. Console logs are ephemeral; Redis stores only repository names for optional stats tracking. 
+          All content is meant for public display on GitHub. 
           <a href="https://github.com/warengonzaga/github-repo-banner#-privacy--transparency" target="_blank" rel="noopener" style="color: #58a6ff;">Learn more</a>
         </p>
       </div>
 
       <div class="sidebar-section">
-        <h2>Contribute</h2>
+        <h2>🤝 Contribute</h2>
         <div class="contribute-links">
           <a href="https://github.com/warengonzaga/github-repo-banner/issues/new" target="_blank" rel="noopener" class="contribute-btn">
             <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -1577,7 +1577,7 @@
       </div>
 
       <div class="sidebar-section">
-        <h2>Self Host</h2>
+        <h2>💻 Self Host</h2>
         <a href="https://railway.com/deploy/github-repo-banner?referralCode=KN9JqT&utm_medium=integration&utm_source=template&utm_campaign=generic" target="_blank" rel="noopener" class="deploy-btn">
           <img src="https://railway.com/button.svg" alt="Deploy on Railway" class="deploy-img">
         </a>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1067,6 +1067,19 @@
         </div>
         <div class="bg-option">
           <span class="new-badge">New</span>
+          <button type="button" class="preset-btn" data-bg="431586-9231A8" data-color="FFFFFF" data-gradient="true">
+            <span class="swatch" style="background: linear-gradient(90deg, #431586, #9231A8);"></span>
+            Railway
+          </button>
+        </div>
+        <div class="bg-option">
+          <span class="new-badge">New</span>
+          <button type="button" class="preset-btn" data-bg="F38020-FBAB41" data-color="FFFFFF" data-gradient="true">
+            <span class="swatch" style="background: linear-gradient(90deg, #F38020, #FBAB41);"></span>
+            Cloudflare
+          </button>
+        </div>
+        <div class="bg-option">
           <button type="button" class="preset-btn" data-bg="E7F9FF-90C4E8" data-color="0060A0" data-gradient="true">
             <span class="swatch" style="background: linear-gradient(90deg, #E7F9FF, #90C4E8);"></span>
             OSSPH
@@ -1091,7 +1104,6 @@
           </button>
         </div>
         <div class="bg-option">
-          <span class="new-badge">New</span>
           <button type="button" class="preset-btn" data-bg="10A37F" data-color="FFFFFF">
             <span class="swatch" style="background: #10a37f;"></span>
             GPT
@@ -1176,7 +1188,7 @@
         <p class="deploy-message">When you deploy your own copy, you're directly supporting this project! 💖</p>
       </div>
 
-      <div class="version-display">v1.1.1</div>
+      <div class="version-display">v1.2.0</div>
     </aside>
   </div>
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -261,6 +261,27 @@
       border-radius: 6px;
       border: 1px solid #30363d;
       flex-shrink: 0;
+      cursor: pointer;
+      transition: all 0.2s;
+      position: relative;
+    }
+
+    .color-preview:hover {
+      transform: scale(1.1);
+      border-color: #58a6ff;
+      box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+    }
+
+    .color-preview:active {
+      transform: scale(1.05);
+    }
+
+    .color-picker-input {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+      pointer-events: none;
     }
 
     .input-with-info {
@@ -1131,7 +1152,8 @@
               <span class="hex-prefix">#</span>
               <input type="text" id="bg-input" value="1A1A1A" placeholder="000000" maxlength="8" />
             </div>
-            <span class="color-preview" id="bg-preview"></span>
+            <span class="color-preview" id="bg-preview" title="Click to open color picker"></span>
+            <input type="color" id="bg-picker" class="color-picker-input" />
           </div>
         </div>
 
@@ -1142,7 +1164,8 @@
               <span class="hex-prefix">#</span>
               <input type="text" id="bg-input-2" value="4A4A4A" placeholder="FFFFFF" maxlength="8" />
             </div>
-            <span class="color-preview" id="bg-preview-2"></span>
+            <span class="color-preview" id="bg-preview-2" title="Click to open color picker"></span>
+            <input type="color" id="bg-picker-2" class="color-picker-input" />
           </div>
         </div>
 
@@ -1153,7 +1176,8 @@
               <span class="hex-prefix">#</span>
               <input type="text" id="color-input" value="FFFFFF" placeholder="FFFFFF" maxlength="8" />
             </div>
-            <span class="color-preview" id="color-preview"></span>
+            <span class="color-preview" id="color-preview" title="Click to open color picker"></span>
+            <input type="color" id="color-picker" class="color-picker-input" />
           </div>
         </div>
 
@@ -1164,7 +1188,8 @@
               <span class="hex-prefix">#</span>
               <input type="text" id="subheader-color-input" value="" placeholder="FFFFFF" maxlength="8" />
             </div>
-            <span class="color-preview" id="subheader-color-preview"></span>
+            <span class="color-preview" id="subheader-color-preview" title="Click to open color picker"></span>
+            <input type="color" id="subheader-color-picker" class="color-picker-input" />
           </div>
         </div>
         </div>
@@ -1671,6 +1696,42 @@
     });
     headerFontInput.addEventListener('input', update);
     subheaderFontInput.addEventListener('input', update);
+
+    // Color picker functionality
+    const bgPicker = document.getElementById('bg-picker');
+    const bgPicker2 = document.getElementById('bg-picker-2');
+    const colorPicker = document.getElementById('color-picker');
+    const subheaderColorPicker = document.getElementById('subheader-color-picker');
+
+    // Function to setup color picker
+    function setupColorPicker(previewEl, pickerEl, inputEl) {
+      // Click preview to open picker
+      previewEl.addEventListener('click', () => {
+        pickerEl.click();
+      });
+
+      // When picker changes, update hex input
+      pickerEl.addEventListener('input', (e) => {
+        const hex = e.target.value.substring(1).toUpperCase();
+        inputEl.value = hex;
+        updateColorPreview();
+        update();
+      });
+
+      // When hex input changes, update picker
+      inputEl.addEventListener('input', () => {
+        const hex = inputEl.value.replace(/^#/, '');
+        if (/^[0-9A-Fa-f]{6}$/.test(hex)) {
+          pickerEl.value = '#' + hex;
+        }
+      });
+    }
+
+    // Setup all color pickers
+    setupColorPicker(bgPreview, bgPicker, bgInput);
+    setupColorPicker(bgPreview2, bgPicker2, bgInput2);
+    setupColorPicker(colorPreview, colorPicker, colorInput);
+    setupColorPicker(subheaderColorPreview, subheaderColorPicker, subheaderColorInput);
 
     // Preset buttons populate input fields
     presetBtns.forEach(btn => {

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -234,6 +234,16 @@
       box-shadow: 0 0 0 3px rgba(210, 153, 34, 0.2);
     }
 
+    input[type="text"].invalid-input {
+      border-color: #d29922;
+      animation: glow-orange 1.5s ease-in-out infinite;
+    }
+
+    input[type="text"].invalid-input:focus {
+      border-color: #d29922;
+      box-shadow: 0 0 0 3px rgba(210, 153, 34, 0.2);
+    }
+
     @keyframes glow-red {
       0%, 100% {
         box-shadow: 0 0 0 0 rgba(248, 81, 73, 0);
@@ -259,6 +269,21 @@
       display: flex;
       gap: 0;
       align-items: center;
+    }
+
+    .font-validation-warning {
+      font-size: 0.6875rem;
+      color: #f85149;
+      margin-top: 0.375rem;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .font-validation-warning svg {
+      width: 12px;
+      height: 12px;
+      fill: currentColor;
     }
 
     .char-counter-separator {
@@ -2031,8 +2056,128 @@
       toggleSubheaderFields();
       update();
     });
-    headerFontInput.addEventListener('input', update);
-    subheaderFontInput.addEventListener('input', update);
+
+    function validateFontName(input) {
+      const value = input.value.trim();
+      if (!value) return { isValid: true, hasInvalidChars: false };
+      
+      // Check for invalid characters (anything not alphanumeric, space, or +)
+      const invalidChars = value.match(/[^a-zA-Z0-9\s+]/g);
+      const hasInvalidChars = invalidChars && invalidChars.length > 0;
+      
+      return {
+        isValid: !hasInvalidChars,
+        hasInvalidChars: hasInvalidChars,
+        invalidChars: hasInvalidChars ? [...new Set(invalidChars)].join('') : ''
+      };
+    }
+
+    // Cache for Google Fonts validation results
+    const fontValidationCache = new Map();
+    let fontValidationTimers = new Map();
+
+    async function checkGoogleFontExists(fontName) {
+      if (!fontName || fontName.trim() === '') return { exists: true };
+      
+      // Check cache first
+      if (fontValidationCache.has(fontName)) {
+        return fontValidationCache.get(fontName);
+      }
+
+      try {
+        // Fetch the Google Fonts CSS to check if font exists
+        const fontFamily = fontName.replace(/\s+/g, '+');
+        const response = await fetch(`https://fonts.googleapis.com/css2?family=${fontFamily}&display=swap`, {
+          method: 'HEAD', // Use HEAD to avoid downloading full CSS
+          mode: 'no-cors' // Required for cross-origin requests
+        });
+        
+        // With no-cors mode, we can't check status, so try to load the CSS
+        const cssResponse = await fetch(`https://fonts.googleapis.com/css2?family=${fontFamily}&display=swap`);
+        const cssText = await cssResponse.text();
+        
+        // Check if the response contains actual font-face definitions
+        // Invalid fonts return a comment or empty response
+        const isValid = cssText.includes('@font-face') || cssText.includes('font-family');
+        
+        const result = { exists: isValid };
+        fontValidationCache.set(fontName, result);
+        return result;
+      } catch (error) {
+        // If fetch fails, assume font doesn't exist
+        const result = { exists: false };
+        fontValidationCache.set(fontName, result);
+        return result;
+      }
+    }
+
+    function updateFontValidation(input, warningId) {
+      const validation = validateFontName(input);
+      let warningEl = document.getElementById(warningId);
+      
+      if (!validation.isValid) {
+        input.classList.add('limit-exceeded');
+        
+        if (!warningEl) {
+          warningEl = document.createElement('div');
+          warningEl.id = warningId;
+          warningEl.className = 'font-validation-warning';
+          input.parentElement.parentElement.appendChild(warningEl);
+        }
+        
+        warningEl.innerHTML = `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Invalid characters removed: "${validation.invalidChars}"`;
+        return;
+      }
+
+      // Check if font exists on Google Fonts (debounced)
+      const fontName = input.value.trim();
+      
+      // Clear existing timer for this input
+      if (fontValidationTimers.has(warningId)) {
+        clearTimeout(fontValidationTimers.get(warningId));
+      }
+
+      // Set new validation timer
+      const timer = setTimeout(async () => {
+        if (!fontName) {
+          input.classList.remove('limit-exceeded');
+          if (warningEl) warningEl.remove();
+          return;
+        }
+
+        const fontCheck = await checkGoogleFontExists(fontName);
+        
+        if (!fontCheck.exists) {
+          input.classList.add('limit-exceeded');
+          
+          if (!warningEl) {
+            warningEl = document.createElement('div');
+            warningEl.id = warningId;
+            warningEl.className = 'font-validation-warning';
+            input.parentElement.parentElement.appendChild(warningEl);
+          }
+          
+          warningEl.innerHTML = `<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path></svg>Font not found on Google Fonts`;
+        } else {
+          input.classList.remove('limit-exceeded');
+          if (warningEl) {
+            warningEl.remove();
+          }
+        }
+      }, 800); // Wait 800ms after user stops typing
+      
+      fontValidationTimers.set(warningId, timer);
+    }
+
+    headerFontInput.addEventListener('input', () => {
+      updateFontValidation(headerFontInput, 'header-font-warning');
+      update();
+    });
+    
+    subheaderFontInput.addEventListener('input', () => {
+      updateFontValidation(subheaderFontInput, 'subheader-font-warning');
+      update();
+    });
 
     // Color picker functionality
     const bgPicker = document.getElementById('bg-picker');

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -935,7 +935,7 @@
 
           <div class="form-group" style="margin-top: 1.5rem;">
             <label class="checkbox-container">
-              <input type="checkbox" id="support" />
+              <input type="checkbox" id="support" checked />
               <div class="checkbox-label">
                 <div class="title">💖 Help spread the word</div>
                 <div class="description">Add a small watermark to help others discover this tool</div>
@@ -1441,8 +1441,9 @@
         params.set('subheaderfont', subheaderFont);
       }
       
-      if (supportCheckbox.checked) {
-        params.set('support', 'true');
+      if (!supportCheckbox.checked) {
+        params.set('support', 'false');
+      } else {
         params.set('watermarkpos', watermarkPosition);
       }
       return '/banner?' + params.toString();
@@ -1593,7 +1594,7 @@
       bgInput2.value = '4A4A4A';
       colorInput.value = 'FFFFFF';
       subheaderColorInput.value = '';
-      supportCheckbox.checked = false;
+      supportCheckbox.checked = true;
       
       // Reset watermark position
       watermarkPosition = 'bottom-right';

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -267,7 +267,6 @@
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       gap: 0.5rem;
-      margin-bottom: 2rem;
     }
 
     .bg-option {
@@ -570,7 +569,7 @@
       resize: vertical;
       font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
       font-size: 0.875rem;
-      background: #0d1117;
+      background: #262C36;
       border: 1px solid #30363d;
       border-radius: 6px;
       padding: 0.75rem;
@@ -899,69 +898,6 @@
         </div>
 
         <div class="content-section">
-          <h2>Output</h2>
-          <div class="output-container">
-            <textarea id="markdown" readonly></textarea>
-            <div class="button-row">
-              <button id="copy-btn">
-                <svg viewBox="0 0 16 16" aria-hidden="true">
-                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
-                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
-                </svg>
-                Copy Markdown
-              </button>
-              <button id="copy-url-btn" class="secondary">
-                <svg viewBox="0 0 16 16" aria-hidden="true">
-                  <path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path>
-                </svg>
-                Copy Image URL
-              </button>
-              <button id="download-btn" class="secondary">
-                <svg viewBox="0 0 16 16" aria-hidden="true">
-                  <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
-                  <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
-                </svg>
-                Download SVG
-              </button>
-              <button id="download-png-btn" class="secondary">
-                <svg viewBox="0 0 16 16" aria-hidden="true">
-                  <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
-                  <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
-                </svg>
-                Download PNG
-              </button>
-            </div>
-          </div>
-
-          <div class="form-group" style="margin-top: 1.5rem;">
-            <label class="checkbox-container">
-              <input type="checkbox" id="support" checked />
-              <div class="checkbox-label">
-                <div class="title">💖 Help spread the word</div>
-                <div class="description">Add a small watermark to help others discover this tool</div>
-              </div>
-              <span class="toggle-switch"></span>
-            </label>
-            
-            <div class="position-selector" id="position-selector">
-              <span class="position-selector-label">Watermark Position</span>
-              <div class="position-options">
-                <button type="button" class="position-btn active" data-position="bottom-right">Bottom Right</button>
-                <button type="button" class="position-btn" data-position="bottom-left">Bottom Left</button>
-                <button type="button" class="position-btn" data-position="top-right">Top Right</button>
-                <button type="button" class="position-btn" data-position="top-left">Top Left</button>
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group" id="sponsor-link" style="margin-top: 1rem;">
-            <div class="sponsor-notice">
-              <span id="sponsor-message">Prefer brand-free banners? Consider <a href="https://github.com/sponsors/warengonzaga" target="_blank" rel="noopener">sponsoring</a> instead! 💖</span>
-            </div>
-          </div>
-        </div>
-
-        <div class="content-section">
           <div class="settings-header">
             <h2>Settings</h2>
             <button id="reset-btn" class="reset-btn" title="Reset to defaults">
@@ -1132,6 +1068,70 @@
         </div>
 
         </div>
+
+        <div class="content-section">
+          <h2>Output</h2>
+          <div class="output-container">
+            <textarea id="markdown" readonly></textarea>
+            <div class="button-row">
+              <button id="copy-btn">
+                <svg viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path>
+                  <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+                </svg>
+                Copy Markdown
+              </button>
+              <button id="copy-url-btn" class="secondary">
+                <svg viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path>
+                </svg>
+                Copy Image URL
+              </button>
+              <button id="download-btn" class="secondary">
+                <svg viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
+                  <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
+                </svg>
+                Download SVG
+              </button>
+              <button id="download-png-btn" class="secondary">
+                <svg viewBox="0 0 16 16" aria-hidden="true">
+                  <path d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z"></path>
+                  <path d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z"></path>
+                </svg>
+                Download PNG
+              </button>
+            </div>
+          </div>
+
+          <div class="form-group" style="margin-top: 1.5rem;">
+            <label class="checkbox-container">
+              <input type="checkbox" id="support" checked />
+              <div class="checkbox-label">
+                <div class="title">💖 Help spread the word</div>
+                <div class="description">Add a small watermark to help others discover this tool</div>
+              </div>
+              <span class="toggle-switch"></span>
+            </label>
+            
+            <div class="position-selector" id="position-selector">
+              <span class="position-selector-label">Watermark Position</span>
+              <div class="position-options">
+                <button type="button" class="position-btn active" data-position="bottom-right">Bottom Right</button>
+                <button type="button" class="position-btn" data-position="bottom-left">Bottom Left</button>
+                <button type="button" class="position-btn" data-position="top-right">Top Right</button>
+                <button type="button" class="position-btn" data-position="top-left">Top Left</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group" id="sponsor-link" style="margin-top: 1rem;">
+            <div class="sponsor-notice">
+              <span id="sponsor-message">Prefer brand-free banners? Consider <a href="https://github.com/sponsors/warengonzaga" target="_blank" rel="noopener">sponsoring</a> instead! 💖</span>
+            </div>
+          </div>
+        </div>
+
         </div>
       </div>
     </main>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -214,6 +214,157 @@
       box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.1);
     }
 
+    input[type="text"].limit-exceeded {
+      border-color: #f85149;
+      animation: glow-red 1.5s ease-in-out infinite;
+    }
+
+    input[type="text"].will-truncate {
+      border-color: #d29922;
+      animation: glow-orange 1.5s ease-in-out infinite;
+    }
+
+    input[type="text"].limit-exceeded:focus {
+      border-color: #f85149;
+      box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.2);
+    }
+
+    input[type="text"].will-truncate:focus {
+      border-color: #d29922;
+      box-shadow: 0 0 0 3px rgba(210, 153, 34, 0.2);
+    }
+
+    @keyframes glow-red {
+      0%, 100% {
+        box-shadow: 0 0 0 0 rgba(248, 81, 73, 0);
+      }
+      50% {
+        box-shadow: 0 0 8px 2px rgba(248, 81, 73, 0.4);
+      }
+    }
+
+    @keyframes glow-orange {
+      0%, 100% {
+        box-shadow: 0 0 0 0 rgba(210, 153, 34, 0);
+      }
+      50% {
+        box-shadow: 0 0 8px 2px rgba(210, 153, 34, 0.4);
+      }
+    }
+
+    .char-counter {
+      font-size: 0.75rem;
+      color: #7d8590;
+      margin-top: 0.375rem;
+      display: flex;
+      gap: 0;
+      align-items: center;
+    }
+
+    .char-counter-separator {
+      margin: 0 0.5rem;
+      color: #484f58;
+      font-weight: 400;
+    }
+
+    .char-counter-part {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .char-counter-part.exceeded {
+      color: #f85149;
+      font-weight: 600;
+    }
+
+    .char-counter-part.warning {
+      color: #d29922;
+      font-weight: 600;
+    }
+
+    .char-counter-part.truncated {
+      color: #d29922;
+      font-weight: 600;
+    }
+
+    .char-counter-info {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      cursor: help;
+      position: relative;
+      z-index: 100;
+    }
+
+    .char-counter-info-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: #30363d;
+      color: #7d8590;
+      font-size: 10px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .char-counter-info-icon:hover {
+      background: #484f58;
+      color: #c9d1d9;
+    }
+
+    .char-counter-tooltip {
+      position: absolute;
+      bottom: calc(100% + 12px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: #1c2128;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 0.75rem;
+      white-space: pre-line;
+      min-width: 200px;
+      max-width: 500px;
+      z-index: 10000;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s;
+      line-height: 1.6;
+      word-break: break-word;
+    }
+
+    .char-counter-tooltip::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 6px solid transparent;
+      border-top-color: #30363d;
+    }
+
+    .char-counter-info-icon.active + .char-counter-tooltip,
+    .char-counter-info:hover .char-counter-tooltip {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .char-counter-part.truncated {
+      color: #d29922;
+      font-weight: 600;
+    }
+
+    .char-counter-part.truncated {
+      color: #d29922;
+      font-weight: 600;
+    }
+
     .color-row {
       display: flex;
       align-items: center;
@@ -1050,7 +1201,7 @@
         <div class="form-group">
           <label for="header">Header Text</label>
           <div class="input-with-info">
-            <input type="text" id="header" value="![github] Hello World 👋" placeholder="Enter your repository title or project name" maxlength="50" />
+            <input type="text" id="header" value="![github] Hello World 👋" placeholder="Enter your repository title or project name" />
             <button type="button" class="info-icon-btn" id="header-info-btn" aria-label="Show emoji and icon help">
               <svg viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
@@ -1069,6 +1220,11 @@
                 <li>Dark theme: "Node ![node](dark)"</li>
               </ul>
             </div>
+          </div>
+          <div class="char-counter" id="header-counter">
+            <span class="char-counter-part" id="header-text-count">Text: 0/50</span>
+            <span class="char-counter-separator">|</span>
+            <span class="char-counter-part" id="header-icon-count">Icons: none</span>
           </div>
         </div>
 
@@ -1099,7 +1255,7 @@
         <div class="form-group">
           <label for="subheader">Sub Header Text (optional)</label>
           <div class="input-with-info">
-            <input type="text" id="subheader" value="Great projects deserve great repository banners" placeholder="Add a compelling tagline or description" maxlength="60" />
+            <input type="text" id="subheader" value="Great projects deserve great repository banners" placeholder="Add a compelling tagline or description" />
             <button type="button" class="info-icon-btn" id="subheader-info-btn" aria-label="Show emoji and icon help">
               <svg viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
@@ -1118,6 +1274,11 @@
                 <li>Dark theme: "Made by ![github](dark)"</li>
               </ul>
             </div>
+          </div>
+          <div class="char-counter" id="subheader-counter">
+            <span class="char-counter-part" id="subheader-text-count">Text: 0/60</span>
+            <span class="char-counter-separator">|</span>
+            <span class="char-counter-part" id="subheader-icon-count">Icons: none</span>
           </div>
         </div>
 
@@ -1692,8 +1853,164 @@
       }, 300);
     }
 
-    headerInput.addEventListener('input', update);
+    // Character counting and validation functions
+    function removeEmojis(text) {
+      // Remove emojis using regex (matches all emoji characters)
+      return text.replace(/[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu, '');
+    }
+
+    function extractIcons(text) {
+      // Match ![icon-name] or ![icon-name](theme)
+      const iconRegex = /!\[([^\]]+)\](?:\([^)]+\))?/g;
+      const icons = [];
+      let match;
+      while ((match = iconRegex.exec(text)) !== null) {
+        icons.push({
+          fullMatch: match[0],
+          name: match[1]
+        });
+      }
+      return icons;
+    }
+
+    function getTextWithoutIconsAndEmojis(text) {
+      // Remove icon syntax first
+      const textWithoutIcons = text.replace(/!\[[^\]]+\](?:\([^)]+\))?/g, '');
+      // Then remove emojis
+      return removeEmojis(textWithoutIcons);
+    }
+
+    // Simulate backend sanitizeHeader truncation logic
+    function simulateTruncation(text, maxLength) {
+      if (text.length <= maxLength) {
+        return text;
+      }
+      
+      let truncated = text.slice(0, maxLength);
+      
+      // Check if we're in the middle of an icon syntax ![...]
+      const lastOpenBracket = truncated.lastIndexOf('![');
+      
+      if (lastOpenBracket !== -1) {
+        const afterOpen = truncated.slice(lastOpenBracket);
+        const hasClosing = afterOpen.includes(']');
+        
+        // If no closing bracket, we cut in the middle of an icon - remove it
+        if (!hasClosing) {
+          truncated = truncated.slice(0, lastOpenBracket);
+        }
+      }
+      
+      return truncated.trimEnd();
+    }
+
+    function validateInput(input, textLimit, iconLimit) {
+      const value = input.value;
+      const icons = extractIcons(value);
+      const textOnly = getTextWithoutIconsAndEmojis(value);
+      
+      // Calculate limits
+      const textLength = textOnly.length;
+      const maxIconLength = Math.max(...icons.map(i => i.name.length), 0);
+      
+      const textExceeded = textLength > textLimit;
+      const iconExceeded = maxIconLength > iconLimit;
+      
+      // Check if content will be truncated by backend
+      const truncated = simulateTruncation(value, textLimit);
+      const willBeTruncated = truncated.length < value.length;
+      
+      return {
+        textLength,
+        textLimit,
+        textExceeded,
+        icons,
+        maxIconLength,
+        iconLimit,
+        iconExceeded,
+        willBeTruncated,
+        anyExceeded: textExceeded || iconExceeded
+      };
+    }
+
+    function updateCharCounter(input, counterEl, textCountEl, iconCountEl, textLimit, iconLimit) {
+      const validation = validateInput(input, textLimit, iconLimit);
+      
+      // Update text counter
+      textCountEl.textContent = `Text: ${validation.textLength}/${validation.textLimit}`;
+      textCountEl.classList.toggle('exceeded', validation.textExceeded);
+      textCountEl.classList.toggle('warning', !validation.textExceeded && validation.textLength > textLimit * 0.9);
+      
+      // Update icon counter with individual icon character counts
+      if (validation.icons.length > 0) {
+        // Compact display with tooltip for details
+        const iconCount = validation.icons.length;
+        const iconDetails = validation.icons.map(i => `![${i.name}] (${i.name.length} chars)`).join('\n');
+
+        iconCountEl.innerHTML = `Icons: ${iconCount} <span class="char-counter-info"><span class="char-counter-info-icon" title="Click for details">i</span><span class="char-counter-tooltip">${iconDetails}</span></span> | Max: ${validation.maxIconLength}/${validation.iconLimit}`;
+        iconCountEl.classList.toggle('exceeded', validation.iconExceeded);
+        iconCountEl.classList.toggle('warning', !validation.iconExceeded && validation.maxIconLength > iconLimit * 0.9);
+      } else {
+        iconCountEl.innerHTML = `Icons: none`;
+        iconCountEl.classList.remove('exceeded', 'warning');
+      }
+      
+      // Add click handler for info icon to toggle tooltip
+      const infoIcon = iconCountEl.querySelector('.char-counter-info-icon');
+      if (infoIcon) {
+        infoIcon.onclick = (e) => {
+          e.stopPropagation();
+          infoIcon.classList.toggle('active');
+          // Remove active class when clicking outside
+          setTimeout(() => {
+            const closeOnClick = (evt) => {
+              if (!infoIcon.contains(evt.target)) {
+                infoIcon.classList.remove('active');
+                document.removeEventListener('click', closeOnClick);
+              }
+            };
+            document.addEventListener('click', closeOnClick);
+          }, 0);
+        };
+      }
+      
+      // Show truncation warning if needed
+      let truncationWarning = counterEl.querySelector('.truncation-warning');
+      if (validation.willBeTruncated) {
+        if (!truncationWarning) {
+          const separator = document.createElement('span');
+          separator.className = 'char-counter-separator';
+          separator.textContent = '|';
+          truncationWarning = document.createElement('span');
+          truncationWarning.className = 'char-counter-part truncated truncation-warning';
+          counterEl.appendChild(separator);
+          counterEl.appendChild(truncationWarning);
+        }
+        truncationWarning.textContent = '⚠️ Content will be truncated';
+      } else if (truncationWarning) {
+        const separator = truncationWarning.previousSibling;
+        if (separator && separator.classList && separator.classList.contains('char-counter-separator')) {
+          separator.remove();
+        }
+        truncationWarning.remove();
+      }
+      
+      // Update input border
+      input.classList.toggle('limit-exceeded', validation.anyExceeded);
+      input.classList.toggle('will-truncate', !validation.anyExceeded && validation.willBeTruncated);
+    }
+
+    headerInput.addEventListener('input', () => {
+      updateCharCounter(headerInput, document.getElementById('header-counter'), 
+        document.getElementById('header-text-count'), 
+        document.getElementById('header-icon-count'), 50, 20);
+      update();
+    });
+    
     subheaderInput.addEventListener('input', () => {
+      updateCharCounter(subheaderInput, document.getElementById('subheader-counter'),
+        document.getElementById('subheader-text-count'),
+        document.getElementById('subheader-icon-count'), 60, 20);
       toggleSubheaderFields();
       update();
     });
@@ -2055,6 +2372,15 @@
       toggleSponsorLink(false); // Don't animate on initial load
       toggleSubheaderFields();
       updateColorPreview();
+      
+      // Initialize character counters
+      updateCharCounter(headerInput, document.getElementById('header-counter'),
+        document.getElementById('header-text-count'),
+        document.getElementById('header-icon-count'), 50, 20);
+      updateCharCounter(subheaderInput, document.getElementById('subheader-counter'),
+        document.getElementById('subheader-text-count'),
+        document.getElementById('subheader-icon-count'), 60, 20);
+      
       const url = buildUrl();
       previewImg.src = url + '&_t=' + Date.now();
       const fullUrl = window.location.origin + url;

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1865,6 +1865,12 @@
     }
 
     // Character counting and validation functions
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
     function removeEmojis(text) {
       // Remove emojis using regex (matches all emoji characters)
       return text.replace(/[\u{1F300}-\u{1F9FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{1F000}-\u{1F02F}\u{1F0A0}-\u{1F0FF}\u{1F100}-\u{1F64F}\u{1F680}-\u{1F6FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu, '');
@@ -1956,13 +1962,13 @@
       if (validation.icons.length > 0) {
         // Compact display with tooltip for details
         const iconCount = validation.icons.length;
-        const iconDetails = validation.icons.map(i => `![${i.name}] (${i.name.length} chars)`).join('\n');
+        const iconDetails = validation.icons.map(i => `![${escapeHtml(i.name)}] (${i.name.length} chars)`).join('\n');
 
-        iconCountEl.innerHTML = `Icons: ${iconCount} <span class="char-counter-info"><span class="char-counter-info-icon" title="Click for details">i</span><span class="char-counter-tooltip">${iconDetails}</span></span> | Max: ${validation.maxIconLength}/${validation.iconLimit}`;
+        iconCountEl.innerHTML = `Icons: ${iconCount} <span class="char-counter-info"><span class="char-counter-info-icon" title="Click for details">i</span><span class="char-counter-tooltip">${escapeHtml(iconDetails)}</span></span> | Max: ${validation.maxIconLength}/${validation.iconLimit}`;
         iconCountEl.classList.toggle('exceeded', validation.iconExceeded);
         iconCountEl.classList.toggle('warning', !validation.iconExceeded && validation.maxIconLength > iconLimit * 0.9);
       } else {
-        iconCountEl.innerHTML = `Icons: none`;
+        iconCountEl.textContent = `Icons: none`;
         iconCountEl.classList.remove('exceeded', 'warning');
       }
       

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -263,6 +263,123 @@
       flex-shrink: 0;
     }
 
+    .input-with-info {
+      position: relative;
+    }
+
+    .input-with-info input[type="text"] {
+      padding-right: 2.5rem;
+    }
+
+    .info-icon-btn {
+      position: absolute;
+      right: 0.5rem;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #7d8590;
+      cursor: pointer;
+      padding: 0.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+      transition: all 0.2s;
+    }
+
+    .info-icon-btn:hover {
+      color: #58a6ff;
+      background: rgba(88, 166, 255, 0.1);
+    }
+
+    .info-icon-btn svg {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
+
+    .info-tooltip {
+      position: absolute;
+      top: calc(100% + 0.5rem);
+      right: 0;
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 1rem;
+      width: 320px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      z-index: 1000;
+      display: none;
+    }
+
+    .info-tooltip.show {
+      display: block;
+      animation: tooltipFadeIn 0.2s ease-out;
+    }
+
+    @keyframes tooltipFadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(-4px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .info-tooltip h4 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #c9d1d9;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .info-tooltip p {
+      font-size: 0.75rem;
+      color: #7d8590;
+      margin: 0 0 0.75rem 0;
+      line-height: 1.5;
+    }
+
+    .info-tooltip ul {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 0.75rem 0;
+    }
+
+    .info-tooltip li {
+      font-size: 0.75rem;
+      color: #7d8590;
+      padding: 0.25rem 0;
+      line-height: 1.5;
+    }
+
+    .info-tooltip li strong {
+      color: #c9d1d9;
+      font-weight: 600;
+    }
+
+    .info-tooltip a {
+      color: #58a6ff;
+      text-decoration: none;
+    }
+
+    .info-tooltip a:hover {
+      text-decoration: underline;
+    }
+
+    .info-tooltip code {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 3px;
+      padding: 0.125rem 0.375rem;
+      font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+      font-size: 0.75rem;
+      color: #c9d1d9;
+    }
+
     .bg-options {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -911,28 +1028,100 @@
         <div class="settings-grid">
         <div class="form-group">
           <label for="header">Header Text</label>
-          <input type="text" id="header" value="Hello World 👋" placeholder="Enter your repository title or project name" maxlength="50" />
+          <div class="input-with-info">
+            <input type="text" id="header" value="Hello World 👋" placeholder="Enter your repository title or project name" maxlength="50" />
+            <button type="button" class="info-icon-btn" id="header-info-btn" aria-label="Show emoji and icon help">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+              </svg>
+            </button>
+            <div class="info-tooltip" id="header-info-tooltip">
+              <h4>Using Emojis & Icons</h4>
+              <p><strong>Emojis:</strong> Copy from <a href="https://emojipedia.org" target="_blank" rel="noopener">Emojipedia</a> and paste</p>
+              <ul>
+                <li>Example: "Hello World 👋"</li>
+              </ul>
+              <p><strong>Simple Icons:</strong> Use <code>![icon-name]</code> from <a href="https://simpleicons.org" target="_blank" rel="noopener">Simple Icons</a></p>
+              <ul>
+                <li>Auto theme: "React ![react] App"</li>
+                <li>Light theme: "GitHub ![github](light)"</li>
+                <li>Dark theme: "Node ![node](dark)"</li>
+              </ul>
+            </div>
+          </div>
         </div>
 
         <div class="form-group">
           <label for="header-font-input">Header Font (Google Fonts)</label>
-          <input type="text" id="header-font-input" value="Permanent Marker" placeholder="Try Roboto, Poppins, Montserrat..." maxlength="50" />
-          <p style="font-size: 0.75rem; color: #7d8590; margin-top: 0.5rem;">
-            Enter any font from <a href="https://fonts.google.com" target="_blank" rel="noopener" style="color: #58a6ff;">Google Fonts</a>. Leave empty for default.
-          </p>
+          <div class="input-with-info">
+            <input type="text" id="header-font-input" value="Permanent Marker" placeholder="Try Roboto, Poppins, Montserrat..." maxlength="50" />
+            <button type="button" class="info-icon-btn" id="header-font-info-btn" aria-label="Show font help">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+              </svg>
+            </button>
+            <div class="info-tooltip" id="header-font-info-tooltip">
+              <h4>Using Google Fonts</h4>
+              <p>Browse fonts at <a href="https://fonts.google.com" target="_blank" rel="noopener">Google Fonts</a> and copy the font name exactly as shown.</p>
+              <p><strong>Examples:</strong></p>
+              <ul>
+                <li>Roboto</li>
+                <li>Permanent Marker</li>
+                <li>Montserrat</li>
+                <li>Poppins</li>
+              </ul>
+              <p style="margin-top: 0.5rem;">Leave empty to use the default font.</p>
+            </div>
+          </div>
         </div>
 
         <div class="form-group">
           <label for="subheader">Sub Header Text (optional)</label>
-          <input type="text" id="subheader" value="Great projects deserve great repository banners" placeholder="Add a compelling tagline or description" maxlength="60" />
+          <div class="input-with-info">
+            <input type="text" id="subheader" value="Great projects deserve great repository banners" placeholder="Add a compelling tagline or description" maxlength="60" />
+            <button type="button" class="info-icon-btn" id="subheader-info-btn" aria-label="Show emoji and icon help">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+              </svg>
+            </button>
+            <div class="info-tooltip" id="subheader-info-tooltip">
+              <h4>Using Emojis & Icons</h4>
+              <p><strong>Emojis:</strong> Copy from <a href="https://emojipedia.org" target="_blank" rel="noopener">Emojipedia</a> and paste</p>
+              <ul>
+                <li>Example: "Made with ❤️"</li>
+              </ul>
+              <p><strong>Simple Icons:</strong> Use <code>![icon-name]</code> from <a href="https://simpleicons.org" target="_blank" rel="noopener">Simple Icons</a></p>
+              <ul>
+                <li>Auto theme: "Built with ![typescript]"</li>
+                <li>Light theme: "Powered by ![vercel](light)"</li>
+                <li>Dark theme: "Made by ![github](dark)"</li>
+              </ul>
+            </div>
+          </div>
         </div>
 
         <div class="form-group" id="subheader-font-group">
           <label for="subheader-font-input">Sub Header Font (Google Fonts)</label>
-          <input type="text" id="subheader-font-input" value="Kinewave" placeholder="Try Inter, Open Sans, Lato..." maxlength="50" />
-          <p style="font-size: 0.75rem; color: #7d8590; margin-top: 0.5rem;">
-            Enter any font from <a href="https://fonts.google.com" target="_blank" rel="noopener" style="color: #58a6ff;">Google Fonts</a>. Leave empty for default.
-          </p>
+          <div class="input-with-info">
+            <input type="text" id="subheader-font-input" value="Kinewave" placeholder="Try Inter, Open Sans, Lato..." maxlength="50" />
+            <button type="button" class="info-icon-btn" id="subheader-font-info-btn" aria-label="Show font help">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+              </svg>
+            </button>
+            <div class="info-tooltip" id="subheader-font-info-tooltip">
+              <h4>Using Google Fonts</h4>
+              <p>Browse fonts at <a href="https://fonts.google.com" target="_blank" rel="noopener">Google Fonts</a> and copy the font name exactly as shown.</p>
+              <p><strong>Examples:</strong></p>
+              <ul>
+                <li>Inter</li>
+                <li>Open Sans</li>
+                <li>Lato</li>
+                <li>Kinewave</li>
+              </ul>
+              <p style="margin-top: 0.5rem;">Leave empty to use the default font.</p>
+            </div>
+          </div>
         </div>
 
         <div class="form-group">
@@ -1812,6 +2001,55 @@
       markdownInput.value = markdown;
       autoResizeTextarea();
     })();
+
+    // Info tooltip functionality
+    const headerInfoBtn = document.getElementById('header-info-btn');
+    const headerInfoTooltip = document.getElementById('header-info-tooltip');
+    const subheaderInfoBtn = document.getElementById('subheader-info-btn');
+    const subheaderInfoTooltip = document.getElementById('subheader-info-tooltip');
+    const headerFontInfoBtn = document.getElementById('header-font-info-btn');
+    const headerFontInfoTooltip = document.getElementById('header-font-info-tooltip');
+    const subheaderFontInfoBtn = document.getElementById('subheader-font-info-btn');
+    const subheaderFontInfoTooltip = document.getElementById('subheader-font-info-tooltip');
+
+    function toggleTooltip(tooltip) {
+      // Close other tooltips
+      document.querySelectorAll('.info-tooltip').forEach(t => {
+        if (t !== tooltip) {
+          t.classList.remove('show');
+        }
+      });
+      tooltip.classList.toggle('show');
+    }
+
+    headerInfoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleTooltip(headerInfoTooltip);
+    });
+
+    subheaderInfoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleTooltip(subheaderInfoTooltip);
+    });
+
+    headerFontInfoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleTooltip(headerFontInfoTooltip);
+    });
+
+    subheaderFontInfoBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleTooltip(subheaderFontInfoTooltip);
+    });
+
+    // Close tooltips when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('.input-with-info')) {
+        document.querySelectorAll('.info-tooltip').forEach(t => {
+          t.classList.remove('show');
+        });
+      }
+    });
   </script>
 </body>
 </html>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1540,6 +1540,17 @@
       </div>
 
       <div class="sidebar-section">
+        <h2>🔒 Privacy Notice</h2>
+        <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590; margin-bottom: 0.75rem;">
+          This service logs button clicks and generated banner URLs to improve features. All content is meant to be publicly displayed on GitHub.
+        </p>
+        <p style="font-size: 0.8125rem; line-height: 1.5; color: #7d8590;">
+          We <strong>don't track</strong> IPs, personal info, or user identities. Logs are ephemeral (console only). 
+          <a href="https://github.com/warengonzaga/github-repo-banner#-privacy--transparency" target="_blank" rel="noopener" style="color: #58a6ff;">Learn more</a>
+        </p>
+      </div>
+
+      <div class="sidebar-section">
         <h2>Contribute</h2>
         <div class="contribute-links">
           <a href="https://github.com/warengonzaga/github-repo-banner/issues/new" target="_blank" rel="noopener" class="contribute-btn">
@@ -2197,6 +2208,15 @@
     });
 
     copyBtn.addEventListener('click', () => {
+      const url = buildUrl();
+      
+      // Log action to server
+      fetch('/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'Copy Markdown', url })
+      }).catch(() => {}); // Silent fail
+      
       navigator.clipboard.writeText(markdownInput.value).then(() => {
         copyBtn.textContent = 'Copied!';
         copyBtn.classList.add('copied');
@@ -2239,6 +2259,14 @@
       // Note: We intentionally do NOT include the support parameter here
       
       const imageUrl = window.location.origin + '/banner?' + params.toString();
+      
+      // Log action to server
+      fetch('/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'Copy Image URL', url: '/banner?' + params.toString() })
+      }).catch(() => {}); // Silent fail
+      
       navigator.clipboard.writeText(imageUrl).then(() => {
         copyUrlBtn.textContent = 'Copied!';
         copyUrlBtn.classList.add('copied');
@@ -2252,6 +2280,14 @@
     downloadBtn.addEventListener('click', async () => {
       try {
         const url = buildUrl();
+        
+        // Log action to server
+        fetch('/log', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'Download SVG', url })
+        }).catch(() => {}); // Silent fail
+        
         const response = await fetch(url);
         const svgBlob = await response.blob();
         const downloadUrl = URL.createObjectURL(svgBlob);
@@ -2278,6 +2314,14 @@
     downloadPngBtn.addEventListener('click', async () => {
       try {
         const url = buildUrl();
+        
+        // Log action to server
+        fetch('/log', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'Download PNG', url })
+        }).catch(() => {}); // Silent fail
+        
         const response = await fetch(url);
         const svgText = await response.text();
         

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1080,6 +1080,13 @@
           </button>
         </div>
         <div class="bg-option">
+          <span class="new-badge">New</span>
+          <button type="button" class="preset-btn" data-bg="013B84-016EEA" data-color="FFFFFF" data-gradient="true">
+            <span class="swatch" style="background: linear-gradient(90deg, #013B84, #016EEA);"></span>
+            Waren
+          </button>
+        </div>
+        <div class="bg-option">
           <button type="button" class="preset-btn" data-bg="E7F9FF-90C4E8" data-color="0060A0" data-gradient="true">
             <span class="swatch" style="background: linear-gradient(90deg, #E7F9FF, #90C4E8);"></span>
             OSSPH

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -2020,14 +2020,14 @@
     headerInput.addEventListener('input', () => {
       updateCharCounter(headerInput, document.getElementById('header-counter'), 
         document.getElementById('header-text-count'), 
-        document.getElementById('header-icon-count'), 50, 20);
+        document.getElementById('header-icon-count'), 50, 50);
       update();
     });
     
     subheaderInput.addEventListener('input', () => {
       updateCharCounter(subheaderInput, document.getElementById('subheader-counter'),
         document.getElementById('subheader-text-count'),
-        document.getElementById('subheader-icon-count'), 60, 20);
+        document.getElementById('subheader-icon-count'), 60, 50);
       toggleSubheaderFields();
       update();
     });

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -2426,10 +2426,10 @@
       // Initialize character counters
       updateCharCounter(headerInput, document.getElementById('header-counter'),
         document.getElementById('header-text-count'),
-        document.getElementById('header-icon-count'), 50, 20);
+        document.getElementById('header-icon-count'), 50, 50);
       updateCharCounter(subheaderInput, document.getElementById('subheader-counter'),
         document.getElementById('subheader-text-count'),
-        document.getElementById('subheader-icon-count'), 60, 20);
+        document.getElementById('subheader-icon-count'), 60, 50);
       
       const url = buildUrl();
       previewImg.src = url + '&_t=' + Date.now();

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -21,7 +21,7 @@ export function sanitizeHeader(raw: string, maxLength: number = 50): string {
   // Truncate at maxLength
   let truncated = stripped.slice(0, maxLength);
   
-  // Check if we're in the middle of an icon syntax ![...]
+  // Check if we're in the middle of an icon syntax ![...] or ![...](theme)
   // If the truncated string has an unclosed icon, remove it
   const lastOpenBracket = truncated.lastIndexOf('![');
   
@@ -33,6 +33,19 @@ export function sanitizeHeader(raw: string, maxLength: number = 50): string {
     // If no closing bracket, we cut in the middle of an icon - remove it
     if (!hasClosing) {
       truncated = truncated.slice(0, lastOpenBracket);
+    } else {
+      // Check if there's a '](' sequence (optional theme suffix)
+      const themeStartIndex = afterOpen.indexOf('](');
+      if (themeStartIndex !== -1) {
+        // Verify if there's a closing ')' after ']('
+        const afterThemeStart = afterOpen.slice(themeStartIndex + 2);
+        const hasClosingParen = afterThemeStart.includes(')');
+        
+        // If no closing ')', we cut in the middle of the theme - remove it
+        if (!hasClosingParen) {
+          truncated = truncated.slice(0, lastOpenBracket);
+        }
+      }
     }
   }
   

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -25,6 +25,16 @@ export function sanitizeFontName(raw: string, maxLength: number = 50): string {
   return cleaned.slice(0, maxLength);
 }
 
+/**
+ * Sanitize Simple Icons slug
+ * Only allows lowercase letters, numbers, and hyphens (Simple Icons format)
+ * Limits length to prevent abuse
+ */
+export function sanitizeIconSlug(raw: string, maxLength: number = 50): string {
+  const cleaned = raw.toLowerCase().replace(/[^a-z0-9-]/g, '');
+  return cleaned.slice(0, maxLength);
+}
+
 const HEX_COLOR_RE = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?([0-9a-fA-F]{2})?$/;
 
 export function isValidHexColor(value: string): boolean {

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -12,7 +12,31 @@ export function escapeXml(str: string): string {
 
 export function sanitizeHeader(raw: string, maxLength: number = 50): string {
   const stripped = raw.replace(/<[^>]*>/g, '');
-  return stripped.slice(0, maxLength);
+  
+  // If within limit, return as is
+  if (stripped.length <= maxLength) {
+    return stripped;
+  }
+  
+  // Truncate at maxLength
+  let truncated = stripped.slice(0, maxLength);
+  
+  // Check if we're in the middle of an icon syntax ![...]
+  // If the truncated string has an unclosed icon, remove it
+  const lastOpenBracket = truncated.lastIndexOf('![');
+  
+  if (lastOpenBracket !== -1) {
+    // Check if there's a closing bracket after the last opening
+    const afterOpen = truncated.slice(lastOpenBracket);
+    const hasClosing = afterOpen.includes(']');
+    
+    // If no closing bracket, we cut in the middle of an icon - remove it
+    if (!hasClosing) {
+      truncated = truncated.slice(0, lastOpenBracket);
+    }
+  }
+  
+  return truncated.trimEnd();
 }
 
 /**


### PR DESCRIPTION
This pull request adds two new gradient background presets, "Railway" and "Cloudflare", to the GitHub repository banner generator. The changes update the UI to include these new presets, update documentation and the version number, and make minor adjustments to the display of existing presets.

**New Background Presets:**
- Added "Railway" and "Cloudflare" gradient background presets to the `BACKGROUNDS` registry in `src/banner/backgrounds.ts`.

**UI Updates:**
- Updated the UI in `src/ui/index.html` to include new preset buttons for "Railway" and "Cloudflare" under the background options, each with a "New" badge and appropriate gradient swatch.
- Removed the "New" badge from the "GPT" solid color background option.

**Documentation and Versioning:**
- Updated the `README.md` to list the new gradients and adjust the solids list.
- Bumped the version in `package.json` and UI footer from `1.1.1` to `1.2.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597L1179-R1191)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional opt-in usage stats with new /stats and /log endpoints, startup stats toggle, and safe Redis-backed tracking (disabled by default).

* **UI**
  * Simple Icons and emoji support in headers, improved icon/emoji rendering, per-field character counters, synchronized color pickers/previews, three new gradient presets, richer tooltips, and expanded Output panel with copy/download actions.

* **Documentation**
  * Privacy & Transparency, deployment/Redis guidance, API docs, and env var updates.

* **Chores**
  * Version bumped to 1.2.0; .env files ignored; node engine updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->