### PR TITLE
🔧 update: update dependencies and add Pexels background image support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ ENABLE_STATS=false
 # Redis Configuration (only required if ENABLE_STATS=true)
 # Example: redis://default:password@host:port or redis://localhost:6379
 REDIS_URL=
+
+# Pexels Integration (optional - enables the in-UI image search widget)
+# Get a free API key at https://www.pexels.com/api/
+# When unset, the /api/pexels/search endpoint returns 503 and the search is hidden
+PEXELS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ REDIS_URL=
 
 # Pexels Integration (optional - enables the in-UI image search widget)
 # Get a free API key at https://www.pexels.com/api/
-# When unset, the /api/pexels/search endpoint returns 503 and the search is hidden
+# When unset, the /api/pexels/search endpoint returns 503
 PEXELS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ When you deploy your own copy, you're directly supporting this project! 💖
 - 📥 **SVG & PNG Download** - Download banners as SVG or PNG directly from the UI
 - ⚡ **Lightning Fast** - Built with Hono framework for optimal performance
 - 🔒 **Secure** - Input sanitization and validation
+- 🖼️ **Background Images** - Use any HTTPS image URL as banner background via `bgimg` parameter
+- 📸 **Pexels Integration** - Search and select background images from Pexels directly in the UI
 - 🚀 **Edge-Ready** - Deploy to modern platforms like Railway
 
 ## 🚀 Quick Start
@@ -85,6 +87,18 @@ https://ghrb.waren.build/banner?header=![react]+![typescript]+Modern+Stack&bg=14
 https://ghrb.waren.build/banner?header=Transparent&bg=00000000&color=ffffff
 https://ghrb.waren.build/banner?header=Semi-Transparent&bg=ffffff80&color=000000
 ```
+
+**Custom Background Image**
+
+```text
+https://ghrb.waren.build/banner?header=My+Project&bgimg=https://images.pexels.com/photos/1261728/pexels-photo-1261728.jpeg&color=ffffff
+```
+
+> Use `bgimg` with any HTTPS image URL. The image is fetched server-side, embedded as base64 in the SVG, and scaled to cover the banner area. If the image fails to load, the banner falls back to the default gradient background. Max image size: 10 MB.
+
+**Pexels Integration**
+
+The UI includes a built-in Pexels image search. To enable it, set the `PEXELS_API_KEY` environment variable with your [Pexels API key](https://www.pexels.com/api/). Search results display landscape-oriented thumbnails that can be selected with a single click.
 
 ## 🌟 Who Uses This
 
@@ -176,6 +190,7 @@ Generate a custom SVG banner.
 | `subheadercolor` | string | No | Same as `color` | Subheader text color |
 | `headerfont` | string | No | - | Google Fonts family name for header (e.g., "Roboto") |
 | `subheaderfont` | string | No | - | Google Fonts family name for subheader (e.g., "Playfair Display") |
+| `bgimg` | string | No | - | HTTPS image URL for background (overrides `bg` when set, max 10 MB) |
 | `support` | boolean | No | `false` | Show support watermark |
 | `watermarkpos` | string | No | `bottom-right` | Watermark position: `top-left`, `top-right`, `bottom-left`, `bottom-right` |
 
@@ -187,6 +202,7 @@ Generate a custom SVG banner.
 | Solid | `HEX` | `ffffff` (single color) |
 | Transparent | `00000000` | Fully transparent |
 | With Opacity | `RRGGBBAA` | `ffffff80` (50% opacity) |
+| Image URL | `bgimg=https://...` | HTTPS URL to any image (fetched and embedded as base64) |
 
 #### Response
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@types/node": "^25.9.1",
         "tsup": "^8.3.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -268,7 +268,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "github-repo-banner",
       "dependencies": {
-        "@hono/node-server": "^1.19.13",
+        "@hono/node-server": "^2.0.4",
         "@wgtechlabs/log-engine": "^2.2.0",
         "dotenv": "^17.2.3",
         "hono": "^4.12.14",
@@ -94,7 +94,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.4", "", { "peerDependencies": { "hono": "^4" } }, "sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A=="],
 
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
-        "@types/node": "^22.10.0",
+        "@types/node": "^25.9.1",
         "tsup": "^8.3.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
@@ -158,7 +158,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@wgtechlabs/log-engine": ["@wgtechlabs/log-engine@2.3.1", "", {}, "sha512-qYwGef4KjcWpFvfC/e6uum/Q2ICTJbaXBZf+qCDmho1rNZ/umqyeDH3Cvk86e2Jy5TkDFPA+rOcTkmrM1rGKkw=="],
 
@@ -272,6 +272,6 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
-    "@types/node": "^22.10.0",
+    "@types/node": "^25.9.1",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^25.9.1",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": "^22"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check": "biome check ."
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.13",
+    "@hono/node-server": "^2.0.4",
     "@wgtechlabs/log-engine": "^2.2.0",
     "dotenv": "^17.2.3",
     "hono": "^4.12.14",

--- a/src/banner/svg-template.ts
+++ b/src/banner/svg-template.ts
@@ -53,11 +53,10 @@ async function fetchImageAsBase64(url: string): Promise<string | null> {
     if (declaredLength && parseInt(declaredLength, 10) > MAX_IMAGE_BYTES)
       return null;
 
-    const rawContentType = response.headers.get('content-type') || 'image/jpeg';
-    const contentType = ALLOWED_IMAGE_TYPES.find((t) =>
-      rawContentType.startsWith(t),
-    );
-    if (!contentType) return null;
+    const rawContentType = response.headers.get('content-type');
+    if (!rawContentType) return null;
+    const contentType = rawContentType.split(';', 1)[0].trim().toLowerCase();
+    if (!ALLOWED_IMAGE_TYPES.includes(contentType)) return null;
 
     const body = response.body;
     if (!body) return null;
@@ -339,7 +338,7 @@ export async function buildBannerSVG(options: BannerOptions): Promise<string> {
     }
   }
 
-  const defs = buildGradientDef(background);
+  let defs = buildGradientDef(background);
   let bgRect: string;
 
   if (background.type === 'image' && background.imageUrl) {
@@ -347,7 +346,18 @@ export async function buildBannerSVG(options: BannerOptions): Promise<string> {
     if (dataUri) {
       bgRect = `<image href="${dataUri}" x="0" y="0" width="${WIDTH}" height="${HEIGHT}" preserveAspectRatio="xMidYMid slice" />`;
     } else {
-      bgRect = `<rect width="${WIDTH}" height="${HEIGHT}" fill="#1a1a1a" />`;
+      const fallback: BackgroundPreset = {
+        id: 'gradient',
+        name: 'Gradient',
+        type: 'gradient',
+        stops: [
+          { offset: '0%', color: '#1a1a1a' },
+          { offset: '100%', color: '#4a4a4a' },
+        ],
+        defaultTextColor: '#ffffff',
+      };
+      defs = buildGradientDef(fallback);
+      bgRect = buildBackground(fallback);
     }
   } else {
     bgRect = buildBackground(background);

--- a/src/banner/svg-template.ts
+++ b/src/banner/svg-template.ts
@@ -25,6 +25,73 @@ function buildGradientDef(bg: BackgroundPreset): string {
   return `<linearGradient id="bg-gradient" x1="0" y1="0" x2="1" y2="0">${stops}</linearGradient>`;
 }
 
+/**
+ * Fetch an image and return it as a base64 data URI for SVG embedding.
+ */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+];
+
+async function fetchImageAsBase64(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; GitHubRepoBanner/1.0; +https://ghrb.waren.build)',
+      },
+      signal: AbortSignal.timeout(10_000),
+      redirect: 'error',
+    });
+    if (!response.ok) return null;
+
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength && parseInt(declaredLength, 10) > MAX_IMAGE_BYTES)
+      return null;
+
+    const rawContentType = response.headers.get('content-type') || 'image/jpeg';
+    const contentType = ALLOWED_IMAGE_TYPES.find((t) =>
+      rawContentType.startsWith(t),
+    );
+    if (!contentType) return null;
+
+    const body = response.body;
+    if (!body) return null;
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    const reader = body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_IMAGE_BYTES) {
+        reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+
+    if (totalBytes === 0) return null;
+
+    const merged = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    const base64 = Buffer.from(merged).toString('base64');
+    return `data:${contentType};base64,${base64}`;
+  } catch {
+    return null;
+  }
+}
+
 function buildBackground(bg: BackgroundPreset): string {
   if (bg.type === 'transparent') {
     return `<rect width="${WIDTH}" height="${HEIGHT}" fill="none" />`;
@@ -273,7 +340,19 @@ export async function buildBannerSVG(options: BannerOptions): Promise<string> {
   }
 
   const defs = buildGradientDef(background);
-  const bgRect = buildBackground(background);
+  let bgRect: string;
+
+  if (background.type === 'image' && background.imageUrl) {
+    const dataUri = await fetchImageAsBase64(background.imageUrl);
+    if (dataUri) {
+      bgRect = `<image href="${dataUri}" x="0" y="0" width="${WIDTH}" height="${HEIGHT}" preserveAspectRatio="xMidYMid slice" />`;
+    } else {
+      bgRect = `<rect width="${WIDTH}" height="${HEIGHT}" fill="#1a1a1a" />`;
+    }
+  } else {
+    bgRect = buildBackground(background);
+  }
+
   const watermark = showWatermark ? buildWatermark(watermarkPosition) : '';
 
   // Determine font families to use - Google Font if specified, otherwise default

--- a/src/banner/types.ts
+++ b/src/banner/types.ts
@@ -1,9 +1,10 @@
 export interface BackgroundPreset {
   id: string;
   name: string;
-  type: 'gradient' | 'solid' | 'transparent';
+  type: 'gradient' | 'solid' | 'transparent' | 'image';
   stops?: Array<{ offset: string; color: string }>;
   color?: string;
+  imageUrl?: string;
   defaultTextColor: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { LogEngine, LogMode } from '@wgtechlabs/log-engine';
 import { Hono } from 'hono';
 import { initRedis, isStatsEnabled } from './config/redis.js';
 import bannerRoute from './routes/banner.js';
+import pexelsRoute from './routes/pexels.js';
 import statsRoute from './routes/stats.js';
 import uiRoute from './routes/ui.js';
 
@@ -45,6 +46,7 @@ app.get('/health', (c) => {
 
 app.route('/', uiRoute);
 app.route('/', bannerRoute);
+app.route('/', pexelsRoute);
 app.route('/', statsRoute);
 
 const port = parseInt(process.env.PORT || '3000', 10);

--- a/src/routes/banner.ts
+++ b/src/routes/banner.ts
@@ -5,6 +5,7 @@ import type { BackgroundPreset } from '../banner/types.js';
 import { getRedis, isStatsEnabled } from '../config/redis.js';
 import {
   isValidHexColor,
+  isValidImageUrl,
   sanitizeFontName,
   sanitizeHeader,
 } from '../utils/sanitize.js';
@@ -47,6 +48,7 @@ bannerRoute.get('/banner', async (c) => {
   const rawHeader = c.req.query('header') || 'Hello World';
   const rawSubheader = c.req.query('subheader') || '';
   const bgParam = c.req.query('bg') || '1a1a1a-4a4a4a'; // Default gradient
+  const bgImgParam = c.req.query('bgimg') || '';
   const colorParam = c.req.query('color') || '';
   const subheaderColorParam = c.req.query('subheadercolor') || '';
   const supportParam = c.req.query('support') || '';
@@ -57,10 +59,18 @@ bannerRoute.get('/banner', async (c) => {
   const header = sanitizeHeader(rawHeader, 50);
   const subheader = rawSubheader ? sanitizeHeader(rawSubheader, 60) : undefined;
 
-  // Parse bg parameter: gradient (hex-hex) or solid (hex)
+  // Parse background: image URL takes priority over color
   let background: BackgroundPreset;
 
-  if (bgParam.includes('-')) {
+  if (bgImgParam && isValidImageUrl(bgImgParam)) {
+    background = {
+      id: 'image',
+      name: 'Image',
+      type: 'image' as const,
+      imageUrl: bgImgParam,
+      defaultTextColor: '#ffffff',
+    };
+  } else if (bgParam.includes('-')) {
     // Gradient: two hex codes separated by hyphen
     const [startHex, endHex] = bgParam.split('-');
     if (isValidHexColor(startHex) && isValidHexColor(endHex)) {

--- a/src/routes/pexels.ts
+++ b/src/routes/pexels.ts
@@ -22,6 +22,7 @@ pexelsRoute.get('/api/pexels/search', async (c) => {
     const url = `${PEXELS_API_URL}/search?query=${encodeURIComponent(query)}&page=${page}&per_page=${perPage}&orientation=${orientation}`;
     const response = await fetch(url, {
       headers: { Authorization: apiKey },
+      signal: AbortSignal.timeout(10_000),
     });
 
     if (!response.ok) {

--- a/src/routes/pexels.ts
+++ b/src/routes/pexels.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono';
+
+const pexelsRoute = new Hono();
+
+const PEXELS_API_URL = 'https://api.pexels.com/v1';
+
+pexelsRoute.get('/api/pexels/search', async (c) => {
+  const apiKey = process.env.PEXELS_API_KEY;
+  if (!apiKey) {
+    return c.json({ error: 'Pexels API not configured' }, 503);
+  }
+
+  const query = (c.req.query('q') || 'nature').slice(0, 100);
+  const page = Math.max(
+    1,
+    parseInt(c.req.query('page') || '1', 10) || 1,
+  ).toString();
+  const perPage = '9';
+  const orientation = 'landscape';
+
+  try {
+    const url = `${PEXELS_API_URL}/search?query=${encodeURIComponent(query)}&page=${page}&per_page=${perPage}&orientation=${orientation}`;
+    const response = await fetch(url, {
+      headers: { Authorization: apiKey },
+    });
+
+    if (!response.ok) {
+      return c.json({ error: 'Pexels API error' }, 502);
+    }
+
+    const data = (await response.json()) as {
+      photos: Array<{
+        id: number;
+        alt: string;
+        photographer: string;
+        src: { landscape: string; medium: string };
+      }>;
+      total_results: number;
+      page: number;
+    };
+
+    const photos = data.photos.map((p) => ({
+      id: p.id,
+      alt: p.alt,
+      photographer: p.photographer,
+      url: p.src.landscape,
+      thumb: p.src.medium,
+    }));
+
+    return c.json({
+      photos,
+      total: data.total_results,
+      page: data.page,
+    });
+  } catch {
+    return c.json({ error: 'Failed to fetch from Pexels' }, 500);
+  }
+});
+
+export default pexelsRoute;

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1383,6 +1383,25 @@
         </div>
         </div>
 
+        <div class="form-group" style="grid-column: 1 / -1;">
+          <label for="bgimg-input">Background Image URL (optional)</label>
+          <input type="text" id="bgimg-input" value="" placeholder="https://images.pexels.com/photos/..." maxlength="2048" />
+          <p style="font-size: 0.75rem; color: #7d8590; margin-top: 0.5rem;">
+            HTTPS image URL. Overrides background color when set. Max 10 MB.
+          </p>
+          <div id="pexels-section" style="margin-top: 0.75rem;">
+            <div style="display: flex; gap: 0.5rem; align-items: center;">
+              <input type="text" id="pexels-query" placeholder="Search Pexels for images..." style="flex: 1;" />
+              <button type="button" id="pexels-search-btn" style="padding: 0.5rem 1rem; background: #238636; color: #fff; border: 1px solid rgba(240,246,252,0.1); border-radius: 6px; cursor: pointer; font-size: 0.875rem; white-space: nowrap;">Search</button>
+              <button type="button" id="pexels-clear-btn" style="padding: 0.5rem 0.75rem; background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; cursor: pointer; font-size: 0.875rem; display: none; white-space: nowrap;">Clear</button>
+            </div>
+            <div id="pexels-results" style="display: none; margin-top: 0.75rem; grid-template-columns: repeat(3, 1fr); gap: 0.5rem;"></div>
+            <p id="pexels-attribution" style="font-size: 0.7rem; color: #7d8590; margin-top: 0.5rem; display: none;">
+              Photos provided by <a href="https://www.pexels.com" target="_blank" rel="noopener" style="color: #58a6ff;">Pexels</a>
+            </p>
+          </div>
+        </div>
+
         <div class="form-group">
           <label>Color Presets (click to apply)</label>
           <div class="bg-options">
@@ -1634,6 +1653,7 @@
     const headerFontInput = document.getElementById('header-font-input');
     const subheaderFontInput = document.getElementById('subheader-font-input');
     const subheaderFontGroup = document.getElementById('subheader-font-group');
+    const bgImgInput = document.getElementById('bgimg-input');
     const supportCheckbox = document.getElementById('support');
     const sponsorLink = document.getElementById('sponsor-link');
     const sponsorMessage = document.getElementById('sponsor-message');
@@ -1823,6 +1843,17 @@
         params.set('subheader', subheader);
       }
       
+      // Background image URL takes priority over color
+      const bgImgUrl = bgImgInput.value.trim();
+      if (bgImgUrl) {
+        try {
+          const parsed = new URL(bgImgUrl);
+          if (parsed.protocol === 'https:') {
+            params.set('bgimg', bgImgUrl);
+          }
+        } catch {}
+      }
+
       // Check if second bg exists to determine gradient or solid
       const bgHex = getBgHex();
       const bgHex2 = getBgHex2();
@@ -2299,6 +2330,71 @@
       update();
     });
 
+    bgImgInput.addEventListener('input', () => {
+      update();
+    });
+
+    // Pexels search
+    const pexelsQuery = document.getElementById('pexels-query');
+    const pexelsSearchBtn = document.getElementById('pexels-search-btn');
+    const pexelsClearBtn = document.getElementById('pexels-clear-btn');
+    const pexelsResults = document.getElementById('pexels-results');
+    const pexelsAttribution = document.getElementById('pexels-attribution');
+
+    async function searchPexels() {
+      const query = pexelsQuery.value.trim();
+      if (!query) return;
+      pexelsSearchBtn.textContent = '...';
+      pexelsSearchBtn.disabled = true;
+      try {
+        const res = await fetch('/api/pexels/search?q=' + encodeURIComponent(query));
+        const data = await res.json();
+        if (data.error) {
+          pexelsResults.style.display = 'none';
+          pexelsAttribution.style.display = 'none';
+          pexelsClearBtn.style.display = 'none';
+          return;
+        }
+        pexelsResults.innerHTML = '';
+        pexelsResults.style.display = 'grid';
+        pexelsAttribution.style.display = 'block';
+        pexelsClearBtn.style.display = 'inline-block';
+        data.photos.forEach(photo => {
+          const img = document.createElement('img');
+          img.src = photo.thumb;
+          img.alt = photo.alt || 'Pexels photo';
+          img.title = 'Photo by ' + photo.photographer;
+          img.style.cssText = 'width:100%;height:80px;object-fit:cover;border-radius:4px;cursor:pointer;border:2px solid transparent;transition:border-color 0.15s;';
+          img.addEventListener('mouseenter', () => { img.style.borderColor = '#1f6feb'; });
+          img.addEventListener('mouseleave', () => { img.style.borderColor = 'transparent'; });
+          img.addEventListener('click', () => {
+            bgImgInput.value = photo.url;
+            update();
+          });
+          pexelsResults.appendChild(img);
+        });
+      } catch {
+        pexelsResults.style.display = 'none';
+      } finally {
+        pexelsSearchBtn.textContent = 'Search';
+        pexelsSearchBtn.disabled = false;
+      }
+    }
+
+    pexelsSearchBtn.addEventListener('click', searchPexels);
+    pexelsQuery.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') searchPexels();
+    });
+    pexelsClearBtn.addEventListener('click', () => {
+      bgImgInput.value = '';
+      pexelsResults.innerHTML = '';
+      pexelsResults.style.display = 'none';
+      pexelsAttribution.style.display = 'none';
+      pexelsClearBtn.style.display = 'none';
+      pexelsQuery.value = '';
+      update();
+    });
+
     supportCheckbox.addEventListener('change', () => {
       toggleSponsorLink();
       update();
@@ -2326,6 +2422,7 @@
       subheaderFontInput.value = 'Kinewave';
       bgInput.value = '1A1A1A';
       bgInput2.value = '4A4A4A';
+      bgImgInput.value = '';
       colorInput.value = 'FFFFFF';
       subheaderColorInput.value = '';
       supportCheckbox.checked = true;
@@ -2390,6 +2487,17 @@
         params.set('subheader', subheader);
       }
       
+      // Background image URL takes priority
+      const bgImgUrl = bgImgInput.value.trim();
+      if (bgImgUrl) {
+        try {
+          const parsed = new URL(bgImgUrl);
+          if (parsed.protocol === 'https:') {
+            params.set('bgimg', bgImgUrl);
+          }
+        } catch {}
+      }
+
       // Use preset bg if active (gradient or transparent), otherwise custom hex
       if (currentPreset) {
         params.set('bg', currentPreset.bg);

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -120,3 +120,60 @@ const HEX_COLOR_RE = /^[0-9a-fA-F]{3}([0-9a-fA-F]{3})?([0-9a-fA-F]{2})?$/;
 export function isValidHexColor(value: string): boolean {
   return HEX_COLOR_RE.test(value);
 }
+
+const MAX_IMAGE_URL_LENGTH = 2048;
+
+/**
+ * Check whether a hostname is a private, loopback, link-local, or otherwise
+ * reserved IP literal. This is a best-effort mitigation against SSRF to
+ * internal services. It does not protect against DNS rebinding (where a public
+ * hostname resolves to a private IP at fetch time); robust protection would
+ * require resolving DNS and pinning the validated IP at fetch time.
+ */
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+
+  // Block well-known private hostnames
+  if (host === 'localhost') return true;
+  if (
+    host.endsWith('.localhost') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.arpa')
+  )
+    return true;
+
+  // IPv6 loopback and unique-local / link-local ranges
+  if (host === '::1') return true;
+  if (host.includes(':') && (host.startsWith('fc') || host.startsWith('fd')))
+    return true; // fc00::/7
+  if (host.includes(':') && host.startsWith('fe80')) return true; // link-local
+  // IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1) - extract the trailing IPv4
+  const mapped = host.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  const ipv4 = mapped ? mapped[1] : host;
+
+  const parts = ipv4.split('.');
+  if (parts.length === 4 && parts.every((p) => /^\d{1,3}$/.test(p))) {
+    const [a, b] = parts.map((p) => parseInt(p, 10));
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 127) return true; // loopback
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 169 && b === 254) return true; // link-local / cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  }
+
+  return false;
+}
+
+export function isValidImageUrl(value: string): boolean {
+  if (!value || value.length > MAX_IMAGE_URL_LENGTH) return false;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:') return false;
+    if (isPrivateHost(url.hostname)) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -171,6 +171,7 @@ export function isValidImageUrl(value: string): boolean {
   try {
     const url = new URL(value);
     if (url.protocol !== 'https:') return false;
+    if (url.username || url.password) return false;
     if (isPrivateHost(url.hostname)) return false;
     return true;
   } catch {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "nodenext",
     "moduleResolution": "nodenext",


### PR DESCRIPTION
This pull request introduces a major new feature: support for custom background images in banners, including a built-in Pexels image search integration in the UI. Users can now specify any HTTPS image URL as a banner background, and optionally search for images directly from Pexels within the app. The changes span backend, frontend, documentation, and configuration to enable this functionality.

**New background image support:**

* Added support for a new `bgimg` query parameter to allow any HTTPS image URL as the banner background. The image is fetched server-side, embedded as a base64 data URI in the SVG, and scaled to cover the banner area. Fallbacks and validation are included, with a maximum image size of 10 MB. (`src/banner/svg-template.ts`, `src/banner/types.ts`, `src/routes/banner.ts`, `src/ui/index.html`) [[1]](diffhunk://#diff-8e3bc883855cdc6ff65107dee097faf1da99df848aa68fcfe31c949857a40e70R28-R94) [[2]](diffhunk://#diff-8e3bc883855cdc6ff65107dee097faf1da99df848aa68fcfe31c949857a40e70L276-R355) [[3]](diffhunk://#diff-82b764383336c1b3032d2376e3796208c32f9a890669cf7900efd04423c0bbc6L4-R7) [[4]](diffhunk://#diff-3d89f3e629060317cd6ccac78c412055b4a4e830ca92f4018750b4d53bf43751R51) [[5]](diffhunk://#diff-3d89f3e629060317cd6ccac78c412055b4a4e830ca92f4018750b4d53bf43751L60-R73) [[6]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R1386-R1404) [[7]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R1846-R1856) [[8]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R2490-R2500) [[9]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R2425)

* Updated the UI to include a new input for background image URLs, with clear priority over color/gradient backgrounds. (`src/ui/index.html`) [[1]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R1386-R1404) [[2]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R1846-R1856) [[3]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R2490-R2500) [[4]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R2425)

**Pexels integration:**

* Added a new `/api/pexels/search` API route that proxies search requests to the Pexels API, enabling in-app search for landscape images. The API is enabled via a new `PEXELS_API_KEY` environment variable. (`src/routes/pexels.ts`, `src/index.ts`, `.env.example`) [[1]](diffhunk://#diff-5afd538453139d0605e10d3209c0690cf13f2962b703522965a8960007f42162R1-R60) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R8) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R49) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR13-R17)

* Enhanced the UI to provide a Pexels image search widget, allowing users to search, preview, and select images with a single click. Includes attribution and clear/reset functionality. (`src/ui/index.html`) [[1]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R1386-R1404) [[2]](diffhunk://#diff-7b1eecf0ce2dc98f65374b031ad0a59dd32294cc122f58e5b35c716758326597R2333-R2397)

**Documentation updates:**

* Updated `README.md` to document the new `bgimg` parameter, explain how to use custom background images, and describe the Pexels integration and its configuration. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R102) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R193) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R205)

**Dependency updates:**

* Upgraded several dependencies, including `@hono/node-server`, `@types/node`, and `typescript`, to their latest major versions. (`package.json`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/warengonzaga/github-repo-banner/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->